### PR TITLE
Add animated temporal progress bar

### DIFF
--- a/src/app/src/components/AnimatedMap.tsx
+++ b/src/app/src/components/AnimatedMap.tsx
@@ -70,7 +70,7 @@ function StatesAndSliderLayer({
 }: {
     spending: MonthlySpendingOverTimeResponse;
 }) {
-    const SLIDER_PRESENT_STEP = 26;
+    const PROGRESS_FINAL_MONTH = 26;
     const map = useMap();
     const [timeValue, setTimeValue] = useState(0);
     const [spendingAtTimeByState, setSpendingAtTimeByState] = useState(() =>
@@ -112,7 +112,7 @@ function StatesAndSliderLayer({
             );
             return () => {
                 clearInterval(monthlyInterval);
-                if(timeValue === SLIDER_PRESENT_STEP){
+                if(timeValue === PROGRESS_FINAL_MONTH){
                     setPlayButtonDisabled(false);
                     setRestartTimeControl(true);
                 }
@@ -157,7 +157,7 @@ function StatesAndSliderLayer({
                         colorScheme={'progress'}
                         aria-label='date-time-progress-bar'
                         min={0}
-                        max={SLIDER_PRESENT_STEP}
+                        max={PROGRESS_FINAL_MONTH}
                         width='100%'
                         maxWidth={'750px'}
                         height='20px'

--- a/src/app/src/components/AnimatedMap.tsx
+++ b/src/app/src/components/AnimatedMap.tsx
@@ -76,7 +76,7 @@ function StatesAndSliderLayer({
     const [spendingAtTimeByState, setSpendingAtTimeByState] = useState(() =>
         getSpendingByStateAtTime(1, spending)
     );
-    const [playButtonDisabled, setPlayButtonDisabled] = useState(false);
+    const [animationEnabled, setAnimationEnabled] = useState(false);
     const [restartTimeControl, setRestartTimeControl] = useState(false);
 
     useEffect(() => {
@@ -103,29 +103,32 @@ function StatesAndSliderLayer({
     }, [map, spendingAtTimeByState]);
 
     useEffect(() => {
-        if(playButtonDisabled){
+        (timeValue % 1 === 0) && spending && setSpendingAtTimeByState(getSpendingByStateAtTime(timeValue, spending));
+        if(timeValue === PROGRESS_FINAL_MONTH){
+            setAnimationEnabled(false);
+            setRestartTimeControl(true);
+        }
+    }, [timeValue, spending])
+
+    useEffect(() => {
+        if(animationEnabled){
             const monthlyInterval = setInterval(() => {
-                setTimeValue(Math.round((timeValue + 0.1)*10)/10);
-                (timeValue % 1 === 0) && spending && setSpendingAtTimeByState(getSpendingByStateAtTime(timeValue, spending));
+                setTimeValue(currentTimeValue => Math.round((currentTimeValue + 0.1)*10)/10);
             },
                 25
             );
             return () => {
                 clearInterval(monthlyInterval);
-                if(timeValue === PROGRESS_FINAL_MONTH){
-                    setPlayButtonDisabled(false);
-                    setRestartTimeControl(true);
-                }
             };
         }
-    }, [playButtonDisabled, timeValue, spending]);
+    }, [animationEnabled]);
 
     function onSelectTimeAnimation(){
         if(restartTimeControl){
             setTimeValue(0);
             setRestartTimeControl(false);
         }
-        setPlayButtonDisabled(true);
+        setAnimationEnabled(true);
     }
 
     return (
@@ -148,7 +151,7 @@ function StatesAndSliderLayer({
                 }}
             />
             <Box mt='575px' textAlign={'center'}>
-                <IconButton aria-label='Play time progress animation' icon={<TimeControlIcon restart={restartTimeControl} />} mr='25px' background='none' onClick={onSelectTimeAnimation} isDisabled={playButtonDisabled} />
+                <IconButton aria-label='Play time progress animation' icon={<TimeControlIcon restart={restartTimeControl} />} mr='25px' background='none' onClick={onSelectTimeAnimation} isDisabled={animationEnabled} />
                 <Tag width='60%' maxWidth={'750px'} background='none'>
                     <TagLabel mt='-30px' mr='-35px' overflow={'none'}>2021</TagLabel>
                     <Progress

--- a/src/app/src/components/AnimatedMap.tsx
+++ b/src/app/src/components/AnimatedMap.tsx
@@ -31,32 +31,36 @@ export default function AnimatedMap() {
                 Allocation of announced award funding over time
             </Heading>
             <Spacer></Spacer>
+            <Box width='100%' pl='20%'>
+                <HStack spacing='0px' border={'1px'} width='210px'>
+                    <Box w='70px' h='40px' bg='white'></Box>
+                    <Box
+                        w='70px'
+                        h='40px'
+                        bg='#94A4DF'
+                        textAlign={'center'}
+                        color={'white'}
+                        fontSize={'sm'}
+                        pt='8px'
+                    >
+                        ≥1% BIL
+                    </Box>
+                    <Box
+                        w='70px'
+                        h='40px'
+                        bg='#465EB5'
+                        textAlign={'center'}
+                        color={'white'}
+                        fontSize={'sm'}
+                        pt='8px'
+                    >
+                        ≥2% BIL
+                    </Box>
+                </HStack>
+            </Box>
             <UsaMapContainer>
                 <StatesAndSliderLayer spending={spendingDataByMonth} />
             </UsaMapContainer>
-            <HStack spacing='0px' border={'1px'}>
-                <Box w='40px' h='40px' bg='white'></Box>
-                <Box
-                    w='40px'
-                    h='40px'
-                    bg='#94A4DF'
-                    textAlign={'center'}
-                    color={'white'}
-                    fontSize={'sm'}
-                >
-                    ≥1% BIL
-                </Box>
-                <Box
-                    w='40px'
-                    h='40px'
-                    bg='#465EB5'
-                    textAlign={'center'}
-                    color={'white'}
-                    fontSize={'sm'}
-                >
-                    ≥2% BIL
-                </Box>
-            </HStack>
         </>
     );
 }

--- a/src/app/src/components/AnimatedMap.tsx
+++ b/src/app/src/components/AnimatedMap.tsx
@@ -105,14 +105,14 @@ function StatesAndSliderLayer({
     useEffect(() => {
         if(playButtonDisabled){
             const monthlyInterval = setInterval(() => {
-                setTimeValue(timeValue + 1);
-                spending && setSpendingAtTimeByState(getSpendingByStateAtTime(timeValue, spending));
+                setTimeValue(Math.round((timeValue + 0.1)*10)/10);
+                (timeValue % 1 === 0) && spending && setSpendingAtTimeByState(getSpendingByStateAtTime(timeValue, spending));
             },
-                250
+                25
             );
             return () => {
                 clearInterval(monthlyInterval);
-                if(timeValue === SLIDER_PRESENT_STEP-1){
+                if(timeValue === SLIDER_PRESENT_STEP){
                     setPlayButtonDisabled(false);
                     setRestartTimeControl(true);
                 }
@@ -149,16 +149,17 @@ function StatesAndSliderLayer({
             />
             <Box mt='575px' textAlign={'center'}>
                 <IconButton aria-label='Play time progress animation' icon={<TimeControlIcon restart={restartTimeControl} />} mr='25px' background='none' onClick={onSelectTimeAnimation} isDisabled={playButtonDisabled} />
-                <Tag width='60%' background='none'>
+                <Tag width='60%' maxWidth={'750px'} background='none'>
                     <TagLabel mt='-30px' mr='-35px' overflow={'none'}>2021</TagLabel>
                     <Progress
                         value={timeValue}
                         opacity={100}
-                        colorScheme={'blackAlpha'}
+                        colorScheme={'progress'}
                         aria-label='date-time-progress-bar'
                         min={0}
                         max={SLIDER_PRESENT_STEP}
                         width='100%'
+                        maxWidth={'750px'}
                         height='20px'
                         mt='10px'
                         display={'inline-block'}

--- a/src/app/src/components/AnimatedMap.tsx
+++ b/src/app/src/components/AnimatedMap.tsx
@@ -3,7 +3,6 @@ import { useMap } from 'react-leaflet';
 import {
     Heading,
     Spacer,
-    HStack,
     Box,
     IconButton,
     Progress,
@@ -23,6 +22,7 @@ import {
     SpendingByGeographyAtMonth,
 } from '../types/api';
 import { spendingDataByMonth } from './dummySpendingDataByMonth';
+import AnimatedMapLegend from './AnimatedMapLegend';
 
 export default function AnimatedMap() {
     return (
@@ -31,33 +31,7 @@ export default function AnimatedMap() {
                 Allocation of announced award funding over time
             </Heading>
             <Spacer></Spacer>
-            <Box width='100%' pl='20%'>
-                <HStack spacing='0px' border={'1px'} width='210px'>
-                    <Box w='70px' h='40px' bg='white'></Box>
-                    <Box
-                        w='70px'
-                        h='40px'
-                        bg='#94A4DF'
-                        textAlign={'center'}
-                        color={'white'}
-                        fontSize={'sm'}
-                        pt='8px'
-                    >
-                        ≥1% BIL
-                    </Box>
-                    <Box
-                        w='70px'
-                        h='40px'
-                        bg='#465EB5'
-                        textAlign={'center'}
-                        color={'white'}
-                        fontSize={'sm'}
-                        pt='8px'
-                    >
-                        ≥2% BIL
-                    </Box>
-                </HStack>
-            </Box>
+            <AnimatedMapLegend />
             <UsaMapContainer>
                 <StatesAndSliderLayer spending={spendingDataByMonth} />
             </UsaMapContainer>

--- a/src/app/src/components/AnimatedMapLegend.tsx
+++ b/src/app/src/components/AnimatedMapLegend.tsx
@@ -1,0 +1,29 @@
+import { HStack, Box } from '@chakra-ui/react';
+
+export function ColorRangeBox({ bg, text }: { bg: string, text?: String }) {
+    return (
+        <Box
+            w='70px'
+            h='40px'
+            bg={bg}
+            textAlign={'center'}
+            color={'white'}
+            fontSize={'sm'}
+            pt='8px'
+        >
+            {text}
+        </Box>
+    );
+}
+
+export default function AnimatedMapLegend() {
+    return (
+        <Box width='100%' pl='20%'>
+            <HStack spacing='0px' border={'1px'} width='210px'>
+                <ColorRangeBox bg='white' />
+                <ColorRangeBox bg='#94A4DF' text='≥1% BIL' />
+                <ColorRangeBox bg='#465EB5' text='≥2% BIL' />
+            </HStack>
+        </Box>
+    );
+}

--- a/src/app/src/components/TimeControlIcon.tsx
+++ b/src/app/src/components/TimeControlIcon.tsx
@@ -1,0 +1,21 @@
+import { Icon } from '@chakra-ui/react';
+
+export default function TimeControlIcon({ restart }: { restart: boolean }) {
+    return restart ? (
+        <Icon viewBox='0 0 512 512' color='black' width='45px' height='45px'>
+            <path
+                fill='currentColor'
+                d='M212.333 224.333H12c-6.627 0-12-5.373-12-12V12C0 5.373 5.373 0 12 0h48c6.627 0 12 5.373 12 12v78.112C117.773 39.279 184.26 7.47 258.175 8.007c136.906.994 246.448 111.623 246.157 248.532C504.041 393.258 393.12 504 256.333 504c-64.089 0-122.496-24.313-166.51-64.215-5.099-4.622-5.334-12.554-.467-17.42l33.967-33.967c4.474-4.474 11.662-4.717 16.401-.525C170.76 415.336 211.58 432 256.333 432c97.268 0 176-78.716 176-176 0-97.267-78.716-176-176-176-58.496 0-110.28 28.476-142.274 72.333h98.274c6.627 0 12 5.373 12 12v48c0 6.627-5.373 12-12 12z'
+                data-attibution='Font Awesome Pro 5.15.4 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc.'
+            />
+        </Icon>
+    ) : (
+        <Icon viewBox='0 0 384 512' color='black' width='55px' height='55px'>
+            <path
+                fill='currentColor'
+                d='M73 39c-14.8-9.1-33.4-9.4-48.5-.9S0 62.6 0 80V432c0 17.4 9.4 33.4 24.5 41.9s33.7 8.1 48.5-.9L361 297c14.3-8.7 23-24.2 23-41s-8.7-32.2-23-41L73 39z'
+                data-attibution='Font Awesome Pro 6.3.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc.'
+            />
+        </Icon>
+    );
+}

--- a/src/app/src/theme.ts
+++ b/src/app/src/theme.ts
@@ -24,7 +24,10 @@ const theme = extendTheme({
     },
     colors: {
         tooltip: {
-          500: '#465EB5',
+            500: '#465EB5',
+        },
+        progress: {
+            500: '#000000',
         },
     },
 });


### PR DESCRIPTION
## Overview

Adds an "animated" progress bar and play button to view spending over time.

Closes #24 

### Demo

https://user-images.githubusercontent.com/36374797/221966180-20530ad2-e91c-4ee1-ae46-6b29a4096f2e.mov

### Notes

- This is just a progress bar with the progress values updated as part of a `setInterval` callback, that way there is one constant in state that updates both the progress bar UI and layer colors for that month value so they're as in sync as possible. That value is broken down into 0.2 increments to allow for a more smooth progress bar transition, and the layers will only update colors once the value arrives at a value that correlates with the start of a new month (e.g. whole number)

## Testing Instructions

- `scripts/server`
- Select play button 
- Confirm progress bar updates and colors follow suit over time
- Confirm play button disabled when running
- Confirm reset button displays and can run animation again

 ## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [ ] CI passes after rebase
