### PR TITLE
Add Pages deployment to CI workflow

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -35,6 +35,34 @@ jobs:
 
       - name: Update
         run: ./scripts/update
+        env:
+          PUBLIC_URL: https://azavea.github.io/green-equity-demo/
 
       - name: Test
         run: ./scripts/test
+
+      - name: Upload site artifact
+        if: github.event_name == 'push'
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: "src/app/build"
+
+  deploy:
+    name: deploy
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add budget tracker [#34](https://github.com/azavea/green-equity-demo/pull/34)
 - Add spending category selector [#30](https://github.com/azavea/green-equity-demo/pull/30)
 - Add spending and state data fetching scripts [#40](https://github.com/azavea/green-equity-demo/pull/40)
+- Add Github Pages deploy to CI workflow [#48](https://github.com/azavea/green-equity-demo/pull/48)
 
 ### Changed
 

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -11,6 +11,7 @@
   "bugs": {
     "url": "https://github.com/azavea/green-equity-demo/issues"
   },
+  "homepage": "https://azavea.github.io/green-equity-demo/",
   "dependencies": {
     "@chakra-ui/react": "^2.5.1",
     "@emotion/react": "^11",

--- a/src/app/public/index.html
+++ b/src/app/public/index.html
@@ -5,10 +5,7 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="actual-project-name"
-    />
+    <meta name="description" content="Green Equity Demo" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a


### PR DESCRIPTION
## Overview


This PR does three things:
- Adds a deployment job to the the CI workflow
- Adds a `homepage` to the package.json so the references in index.html point to the correct place when deployed
- Adds a step to the build job to create an artifact of the build directory so it can be used by the deployment job

Closes #33 

### Notes

I had to update a few other things to get this to work:
 - Enable Pages from GitHub Actions in the project Settings > Pages on Github
 - Add allowed branches to the `github-pages` environment in Settings > Environments > `github-pages`

## Testing Instructions

- https://azavea.github.io/green-equity-demo/
  - [x] Ensure everything looks correct and works well

Two ways to test the workflow
1. Create a `test/`, `release/`, or `hotfix/` branch of this branch and push to GH
2. Trigger manually with GH CLI:
```
gh workflow run .github/workflows/continuous_integration.yml --ref ms/add-github-pages
```



 ## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [ ] CI passes after rebase
