### PR TITLE
Fix category percentages in tooltips, improve agency handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,29 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add sandbox for testing usaspending.gov endpoint [#10](https://github.com/azavea/green-equity-demo/pull/10)
-- Add US state boundary GeoJSON [#6](https://github.com/azavea/green-equity-demo/pull/6)
-- Add redux store and RTK query API client [#15](https://github.com/azavea/green-equity-demo/pull/15)
-- Add leaflet and US States [#16](https://github.com/azavea/green-equity-demo/pull/16)
-- Add per-capita map markers [#27](https://github.com/azavea/green-equity-demo/pull/27)
-- Add per-capita map legend [#29](https://github.com/azavea/green-equity-demo/pull/29)
-- Add state data tooltips [#36](https://github.com/azavea/green-equity-demo/pull/36)
-- Add bar charts to state data tooltips [#42](https://github.com/azavea/green-equity-demo/pull/42)
-- Add budget tracker [#34](https://github.com/azavea/green-equity-demo/pull/34)
-- Add spending category selector [#30](https://github.com/azavea/green-equity-demo/pull/30)
-- Add spending and state data fetching scripts [#40](https://github.com/azavea/green-equity-demo/pull/40)
-- Add Github Pages deploy to CI workflow [#48](https://github.com/azavea/green-equity-demo/pull/48)
-- Add data attribution section [#49](https://github.com/azavea/green-equity-demo/pull/49)
-- Add additional lato font weights for Chakra UI [#55](https://github.com/azavea/green-equity-demo/pull/55)
+-   Add sandbox for testing usaspending.gov endpoint [#10](https://github.com/azavea/green-equity-demo/pull/10)
+-   Add US state boundary GeoJSON [#6](https://github.com/azavea/green-equity-demo/pull/6)
+-   Add redux store and RTK query API client [#15](https://github.com/azavea/green-equity-demo/pull/15)
+-   Add leaflet and US States [#16](https://github.com/azavea/green-equity-demo/pull/16)
+-   Add per-capita map markers [#27](https://github.com/azavea/green-equity-demo/pull/27)
+-   Add per-capita map legend [#29](https://github.com/azavea/green-equity-demo/pull/29)
+-   Add state data tooltips [#36](https://github.com/azavea/green-equity-demo/pull/36)
+-   Add bar charts to state data tooltips [#42](https://github.com/azavea/green-equity-demo/pull/42)
+-   Add budget tracker [#34](https://github.com/azavea/green-equity-demo/pull/34)
+-   Add spending category selector [#30](https://github.com/azavea/green-equity-demo/pull/30)
+-   Add spending and state data fetching scripts [#40](https://github.com/azavea/green-equity-demo/pull/40)
+-   Add Github Pages deploy to CI workflow [#48](https://github.com/azavea/green-equity-demo/pull/48)
+-   Add data attribution section [#49](https://github.com/azavea/green-equity-demo/pull/49)
+-   Add additional lato font weights for Chakra UI [#55](https://github.com/azavea/green-equity-demo/pull/55)
 
 ### Changed
 
-- Use Closes # in PR template [#9](https://github.com/azavea/green-equity-demo/pull/9)
-- Change map to Albers USA projection [#31](https://github.com/azavea/green-equity-demo/pull/31)
-- Place state markers at the points farthest from edges [#45](https://github.com/azavea/green-equity-demo/pull/45)
+-   Use Closes # in PR template [#9](https://github.com/azavea/green-equity-demo/pull/9)
+-   Change map to Albers USA projection [#31](https://github.com/azavea/green-equity-demo/pull/31)
+-   Place state markers at the points farthest from edges [#45](https://github.com/azavea/green-equity-demo/pull/45)
 
 ### Fixed
 
-- Fix layout issues [#53](https://github.com/azavea/green-equity-demo/pull/53)
+-   Fix layout issues [#53](https://github.com/azavea/green-equity-demo/pull/53)
+-   Fix tooltip percentage calculations and improve agency lookups [#54](https://github.com/azavea/green-equity-demo/pull/54)
 
 ### Removed

--- a/src/app/dataScripts/fetchData.ts
+++ b/src/app/dataScripts/fetchData.ts
@@ -1,5 +1,5 @@
 import { mkdir } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
+import { existsSync, writeFile } from 'node:fs';
 
 import { dataDir } from './nodeConstants';
 
@@ -11,7 +11,23 @@ async function fetchData() {
         await mkdir(dataDir);
     }
 
-    await Promise.all([fetchStatesData(), fetchPerCapitaSpendingData()]);
+    try {
+        await Promise.all([fetchStatesData(), fetchPerCapitaSpendingData()]);
+    } catch {
+        // Data not fetched.
+        return;
+    }
+
+    const today = new Date();
+    const todayJson = JSON.stringify({
+        lastUpdated: today.toISOString().substring(0, 10),
+    });
+    writeFile(
+        'src/data/lastUpdated.json',
+        todayJson,
+        { flag: 'w+' },
+        err => {}
+    );
 }
 
 fetchData();

--- a/src/app/dataScripts/fetchPerCapitaSpendingData.ts
+++ b/src/app/dataScripts/fetchPerCapitaSpendingData.ts
@@ -17,7 +17,7 @@ export default async function fetchPerCapitaSpendingData() {
     console.log('Fetching per-capita spending data...');
 
     await Promise.all([
-        writeSpendingDataFile(),
+        writeSpendingDataFile(Category.ALL),
         writeSpendingDataFile(Category.CLIMATE),
         writeSpendingDataFile(Category.CIVIL_WORKS),
         writeSpendingDataFile(Category.TRANSPORTATION),
@@ -26,14 +26,12 @@ export default async function fetchPerCapitaSpendingData() {
     ]);
 }
 
-async function writeSpendingDataFile(category?: Category) {
-    const filename = path.join(dataDir, `${category ?? 'all'}.spending.json`);
+async function writeSpendingDataFile(category: Category) {
+    const filename = path.join(dataDir, `${category}.spending.json`);
 
     if (existsSync(filename)) {
         console.warn(
-            `  Skipping ${
-                category ?? 'All'
-            } spending because the file already exists.`
+            `  Skipping ${category} spending because the file already exists.`
         );
         return Promise.reject();
     }

--- a/src/app/dataScripts/fetchPerCapitaSpendingData.ts
+++ b/src/app/dataScripts/fetchPerCapitaSpendingData.ts
@@ -35,7 +35,7 @@ async function writeSpendingDataFile(category?: Category) {
                 category ?? 'All'
             } spending because the file already exists.`
         );
-        return;
+        return Promise.reject();
     }
 
     const requestBody = getDefaultSpendingByGeographyRequest();

--- a/src/app/src/cachedApiQuery.ts
+++ b/src/app/src/cachedApiQuery.ts
@@ -8,7 +8,7 @@ import { getCategoryForAgencies } from './util';
 import { Category } from './enums';
 
 import states from './data/states.json';
-import allSpending from './data/all.spending.json';
+import allSpending from './data/All categories.spending.json';
 import broadbandSpending from './data/Broadband.spending.json';
 import civilWorksSpending from './data/Civil Works.spending.json';
 import climateSpending from './data/Climate.spending.json';

--- a/src/app/src/cachedApiQuery.ts
+++ b/src/app/src/cachedApiQuery.ts
@@ -54,11 +54,9 @@ function getSpendingByGeography(
 ): SpendingByGeographyResponse {
     const category = request.filters.agencies
         ? getCategoryForAgencies(request.filters.agencies)
-        : undefined;
+        : Category.ALL;
 
-    const spending = category
-        ? getSpendingForCategory(category)
-        : (allSpending as SpendingByGeographyResponse);
+    const spending = getSpendingForCategory(category);
 
     if (request.geo_layer_filters) {
         return {
@@ -86,6 +84,8 @@ function getSpendingForCategory(
             return otherSpending as SpendingByGeographyResponse;
         case Category.TRANSPORTATION:
             return transportationSpending as SpendingByGeographyResponse;
+        case Category.ALL:
+            return allSpending as SpendingByGeographyResponse;
     }
 }
 

--- a/src/app/src/components/AnimatedMap.tsx
+++ b/src/app/src/components/AnimatedMap.tsx
@@ -63,7 +63,7 @@ export default function AnimatedMap() {
     return (
         <>
             <Heading variant='subtitle'>
-                Allocation of announced award funding over time
+                Allocation of awarded funding over time
             </Heading>
             <Spacer></Spacer>
             <AnimatedMapLegend />

--- a/src/app/src/components/Attribution.tsx
+++ b/src/app/src/components/Attribution.tsx
@@ -3,9 +3,12 @@ import { Box, Link, List, ListItem, Text } from '@chakra-ui/react';
 import { getAgenciesForCategory } from '../util';
 import { AgencyTier, Category } from '../enums';
 
+import lastUpdated from '../data/lastUpdated.json';
 import { Agency } from '../types/api';
 
 export default function Attribution() {
+    const date = new Date(lastUpdated.lastUpdated);
+
     return (
         <Box ml={2} width='650px'>
             <details style={{ alignSelf: 'start' }}>
@@ -19,8 +22,8 @@ export default function Attribution() {
                     </Link>{' '}
                     API operated by the U.S. Department of the Treasury, Bureau
                     of the Fiscal Service. Data updates are anticipated to be
-                    made on an ad hoc basis. The most recent date data was
-                    fetched is noted at the top of the page.
+                    made on an ad hoc basis. (Last update:{' '}
+                    {date.toLocaleDateString()})
                 </Text>
                 <Text fontSize={12} pt={1}>
                     The query made to usaspending.gov requests the aggregated

--- a/src/app/src/components/Attribution.tsx
+++ b/src/app/src/components/Attribution.tsx
@@ -54,9 +54,14 @@ export default function Attribution() {
                     on the assignments shown in the .xlsx file included with
                     that dashboard.
                 </Text>
-                {Object.values(Category).map(category => (
-                    <AgencyList key={category.toString()} category={category} />
-                ))}
+                {Object.values(Category)
+                    .filter(c => c !== Category.ALL)
+                    .map(category => (
+                        <AgencyList
+                            key={category.toString()}
+                            category={category}
+                        />
+                    ))}
             </details>
         </Box>
     );
@@ -76,7 +81,7 @@ function AgencyList({ category }: { category: Category }) {
                 Agencies for {category.toString()} spending:
             </Text>
             <List fontSize={12} pt={1}>
-                {getAgenciesForCategory(category).map(agency => (
+                {getAgenciesForCategory(category)?.map(agency => (
                     <ListItem key={agency.name} ml={2}>
                         {niceAgencyName(agency)}
                     </ListItem>

--- a/src/app/src/components/Attribution.tsx
+++ b/src/app/src/components/Attribution.tsx
@@ -38,10 +38,11 @@ export default function Attribution() {
                     <Link href='https://d2d.gsa.gov/report/bipartisan-infrastructure-law-bil-maps-dashboard'>
                         Bipartisan Infrastructure Law (BIL) Maps Dashboard
                     </Link>
-                    , which consumes the same data source, is informative: "All
-                    announcement data represented on these maps, including award
-                    and project locations and funding amounts, is preliminary
-                    and non-binding. Awards may be contingent on meeting certain
+                    , which consumes the same data source, is informative,
+                    despite also including announced funding: "All announcement
+                    data represented on these maps, including award and project
+                    locations and funding amounts, is preliminary and
+                    non-binding. Awards may be contingent on meeting certain
                     requirements. Data represents announced funding (formula and
                     discretionary) as of January 13, 2023. This is a small
                     subset of what the Bipartisan Infrastructure Law will fund

--- a/src/app/src/components/BudgetTracker.tsx
+++ b/src/app/src/components/BudgetTracker.tsx
@@ -3,6 +3,7 @@ import { Box, CircularProgress, HStack, Text, VStack } from '@chakra-ui/react';
 
 import { useGetSpendingByGeographyQuery } from '../api';
 import { getDefaultSpendingByGeographyRequest } from '../util';
+import lastUpdated from '../data/lastUpdated.json';
 
 export default function BudgetTracker() {
     const { data: spending } = useGetSpendingByGeographyQuery(
@@ -17,6 +18,8 @@ export default function BudgetTracker() {
             ),
         [spending?.results]
     );
+
+    const date = new Date(lastUpdated.lastUpdated);
 
     return (
         <Box
@@ -36,7 +39,9 @@ export default function BudgetTracker() {
                     <Text fontSize={20} fontWeight={500}>
                         $550B available in bill
                     </Text>
-                    <Text fontSize={14}>Updated Jan 13, 2023</Text>
+                    <Text fontSize={14}>
+                        Updated {date.toLocaleDateString()}
+                    </Text>
                 </VStack>
                 {spendingSum ? (
                     <BudgetTrackerProgressBar spending={spendingSum} />

--- a/src/app/src/components/BudgetTracker.tsx
+++ b/src/app/src/components/BudgetTracker.tsx
@@ -87,7 +87,7 @@ function BudgetTrackerProgressBarProgress({ spending }: { spending: number }) {
                     color: 'white',
                 }}
             >
-                {spendingBillions.toFixed()}B announced
+                {spendingBillions.toFixed()}B awarded
             </div>
             <div
                 style={{

--- a/src/app/src/components/PerCapitaMap.tsx
+++ b/src/app/src/components/PerCapitaMap.tsx
@@ -56,6 +56,11 @@ export default function PerCapitaMap() {
     const { data: broadbandData, isFetching: isFetchingBroadband } =
         useGetSpendingByGeographyQuery(requestForCategory(Category.BROADBAND));
 
+    const { data: civilWorksData, isFetching: isFetchingCivilWorks } =
+        useGetSpendingByGeographyQuery(
+            requestForCategory(Category.CIVIL_WORKS)
+        );
+
     const { data: climateData, isFetching: isFetchingClimate } =
         useGetSpendingByGeographyQuery(requestForCategory(Category.CLIMATE));
 
@@ -72,6 +77,7 @@ export default function PerCapitaMap() {
         isFetching ||
         isFetchingStates ||
         isFetchingBroadband ||
+        isFetchingCivilWorks ||
         isFetchingClimate ||
         isFetchingTransportation ||
         isFetchingOther;
@@ -83,18 +89,21 @@ export default function PerCapitaMap() {
                 state.code,
                 new Map<Category, number>()
             );
-            Object.values(Category)
-                .filter(cat => cat !== Category.CIVIL_WORKS)
-                .forEach(cat =>
-                    spendingByCategoryByState
-                        .get(state.code)!
-                        .set(cat as Category, 0)
-                );
+            Object.values(Category).forEach(cat =>
+                spendingByCategoryByState
+                    .get(state.code)!
+                    .set(cat as Category, 0)
+            );
         });
         broadbandData!.results.forEach(stateData => {
             spendingByCategoryByState
                 .get(stateData.shape_code)
                 ?.set(Category.BROADBAND, stateData.aggregated_amount);
+        });
+        civilWorksData!.results.forEach(stateData => {
+            spendingByCategoryByState
+                .get(stateData.shape_code)
+                ?.set(Category.CIVIL_WORKS, stateData.aggregated_amount);
         });
         climateData!.results.forEach(stateData => {
             spendingByCategoryByState

--- a/src/app/src/components/SpendingCategorySelector.tsx
+++ b/src/app/src/components/SpendingCategorySelector.tsx
@@ -6,15 +6,15 @@ export default function SpendingCategorySelector({
     value,
     onChange,
 }: {
-    value?: Category;
-    onChange: (category?: Category) => void;
+    value: Category;
+    onChange: (category: Category) => void;
 }) {
     function CategoryButton({
         category,
         isFirst,
         isLast,
     }: {
-        category?: Category;
+        category: Category;
         isFirst?: boolean;
         isLast?: boolean;
     }) {
@@ -37,14 +37,14 @@ export default function SpendingCategorySelector({
                 _hover={{ background: 'rgba(32, 81, 255, 0.21)' }}
                 onClick={() => onChange(category)}
             >
-                {category ?? 'All categories'}
+                {category}
             </Box>
         );
     }
 
     return (
         <HStack mb={75} zIndex={1}>
-            <CategoryButton isFirst />
+            <CategoryButton category={Category.ALL} isFirst />
             <CategoryButton category={Category.BROADBAND} />
             <CategoryButton category={Category.CIVIL_WORKS} />
             <CategoryButton category={Category.CLIMATE} />

--- a/src/app/src/components/SpendingCategorySelector.tsx
+++ b/src/app/src/components/SpendingCategorySelector.tsx
@@ -46,6 +46,7 @@ export default function SpendingCategorySelector({
         <HStack mb={75} zIndex={1}>
             <CategoryButton isFirst />
             <CategoryButton category={Category.BROADBAND} />
+            <CategoryButton category={Category.CIVIL_WORKS} />
             <CategoryButton category={Category.CLIMATE} />
             <CategoryButton category={Category.TRANSPORTATION} />
             <CategoryButton category={Category.OTHER} isLast />

--- a/src/app/src/components/SpendingTooltip.tsx
+++ b/src/app/src/components/SpendingTooltip.tsx
@@ -15,6 +15,7 @@ import {
 } from '@chakra-ui/react';
 import { Category } from '../enums';
 import { abbreviateNumber } from '../util';
+import { SpendingByGeographySingleResult } from '../types/api';
 
 export default function SpendingTooltip({
     state,
@@ -29,7 +30,10 @@ export default function SpendingTooltip({
     dollarsPerCapita: number;
     allSpending: number;
     population: number;
-    spendingByCategory: Map<Category, number>;
+    spendingByCategory: Map<
+        Category,
+        SpendingByGeographySingleResult | undefined
+    >;
 }) {
     const roundedPercent = (amount: number, total: number) => {
         return Math.round(((amount ?? 0) / total) * 100);
@@ -57,10 +61,13 @@ export default function SpendingTooltip({
                         </Text>
                     </Box>
                     <Box>
-                        {Array.from(spendingByCategory, ([cat, amount]) => {
+                        {Array.from(spendingByCategory, ([cat, result]) => {
                             if (cat === Category.ALL) {
                                 return null;
                             }
+
+                            const amount = result?.aggregated_amount ?? 0;
+
                             return (
                                 <React.Fragment
                                     key={`tooltipCategory-${stateCode}-${cat.toString()}`}

--- a/src/app/src/components/SpendingTooltip.tsx
+++ b/src/app/src/components/SpendingTooltip.tsx
@@ -20,14 +20,14 @@ export default function SpendingTooltip({
     state,
     stateCode,
     dollarsPerCapita,
-    funding,
+    allSpending,
     population,
     spendingByCategory,
 }: {
     state: string;
     stateCode: string;
     dollarsPerCapita: number;
-    funding: number;
+    allSpending: number;
     population: number;
     spendingByCategory: Map<Category, number>;
 }) {
@@ -50,7 +50,7 @@ export default function SpendingTooltip({
                     </Box>
                     <Box>
                         <Text fontWeight={'medium'}>
-                            Funding: ${abbreviateNumber(funding)}
+                            Funding: ${abbreviateNumber(allSpending)}
                         </Text>
                         <Text fontWeight={'medium'}>
                             Population: {abbreviateNumber(population)}
@@ -58,19 +58,25 @@ export default function SpendingTooltip({
                     </Box>
                     <Box>
                         {Array.from(spendingByCategory, ([cat, amount]) => {
+                            if (cat === Category.ALL) {
+                                return null;
+                            }
                             return (
                                 <React.Fragment
                                     key={`tooltipCategory-${stateCode}-${cat.toString()}`}
                                 >
                                     <Text>{cat.toString()}:</Text>
                                     <Text>
-                                        {roundedPercent(amount, funding)}%
+                                        {roundedPercent(amount, allSpending)}%
                                     </Text>
                                     <Progress
                                         mb={2}
                                         colorScheme='tooltip'
                                         size='lg'
-                                        value={roundedPercent(amount, funding)}
+                                        value={roundedPercent(
+                                            amount,
+                                            allSpending
+                                        )}
                                     />
                                 </React.Fragment>
                             );

--- a/src/app/src/constants.ts
+++ b/src/app/src/constants.ts
@@ -41,7 +41,7 @@ export const STATE_STYLE_HOVER: PathOptions = Object.freeze({
     weight: 2,
 });
 
-export const MAP_CONTAINER_NEGATIVE_MARGIN = 250;
+export const MAP_CONTAINER_NEGATIVE_MARGIN = 290;
 
 export const MARKER_OVERRIDES: { [stateCode: string]: LatLngTuple } =
     Object.freeze({

--- a/src/app/src/enums.ts
+++ b/src/app/src/enums.ts
@@ -15,6 +15,7 @@ export enum GeoLayer {
 }
 
 export enum Category {
+    ALL = 'All categories',
     BROADBAND = 'Broadband',
     CIVIL_WORKS = 'Civil Works',
     CLIMATE = 'Climate',

--- a/src/app/src/enums.ts
+++ b/src/app/src/enums.ts
@@ -15,10 +15,10 @@ export enum GeoLayer {
 }
 
 export enum Category {
-    CLIMATE = 'Climate',
-    CIVIL_WORKS = 'Civil Works',
-    TRANSPORTATION = 'Transportation',
     BROADBAND = 'Broadband',
+    CIVIL_WORKS = 'Civil Works',
+    CLIMATE = 'Climate',
+    TRANSPORTATION = 'Transportation',
     OTHER = 'Other',
 }
 

--- a/src/app/src/types/api.d.ts
+++ b/src/app/src/types/api.d.ts
@@ -32,16 +32,18 @@ export type SpendingByGeographyRequest = {
     geo_layer_filters?: string[];
 };
 
+export type SpendingByGeographySingleResult = {
+    shape_code: string;
+    display_name: string;
+    aggregated_amount: number;
+    population: number;
+    per_capita: number;
+};
+
 export type SpendingByGeographyResponse = {
     geo_layer: GeoLayer;
     scope: Scope;
-    results: {
-        shape_code: string;
-        display_name: string;
-        aggregated_amount: number;
-        population: number;
-        per_capita: number;
-    }[];
+    results: SpendingByGeographySingleResult[];
 };
 
 export type MonthlySpendingOverTimeResponse = {

--- a/src/app/src/util.ts
+++ b/src/app/src/util.ts
@@ -29,102 +29,126 @@ export function getDefaultSpendingByGeographyRequest(): SpendingByGeographyReque
     };
 }
 
-const baseAgency = {
+const baseSubAgency = {
     type: AgencyType.AWARDING,
     tier: AgencyTier.SUB,
 };
 
-export function getAgenciesForCategory(category: Category): Agency[] {
+const baseTopAgency = {
+    type: AgencyType.AWARDING,
+    tier: AgencyTier.TOP,
+};
+
+// These agencies cross-cut among our categories. So we filter
+// on their subagencies instead.
+const USDA = 'Department of Agriculture';
+const COMMERCE = 'Department of Commerce';
+const DHS = 'Department of Homeland Security';
+
+export function getAgenciesForCategory(
+    category: Category
+): Agency[] | undefined {
     switch (category) {
         case Category.CLIMATE:
             return [
-                { ...baseAgency, name: 'Bureau of Reclamation' },
+                { ...baseTopAgency, name: 'Department of Energy' },
+                { ...baseTopAgency, name: 'Department of the Interior' },
                 {
-                    ...baseAgency,
+                    ...baseTopAgency,
+                    name: 'Department of Health and Human Services',
+                },
+                { ...baseTopAgency, name: 'Environmental Protection Agency' },
+                {
+                    ...baseSubAgency,
+                    name: 'Forest Service',
+                    toptier_name: USDA,
+                },
+                {
+                    ...baseSubAgency,
                     name: 'Natural Resources Conservation Service',
+                    toptier_name: USDA,
                 },
-                { ...baseAgency, name: 'Bureau of Indian Affairs' },
-                { ...baseAgency, name: 'State and Tribal Assistance Grants' }, // EP
-                { ...baseAgency, name: 'Department-Wide Programs' }, // Interio
-                { ...baseAgency, name: 'Hazardous Substance Superfund' },
-                { ...baseAgency, name: 'Forest Service' },
-                { ...baseAgency, name: 'Federal Emergency Management Agency' },
                 {
-                    ...baseAgency,
+                    ...baseSubAgency,
+                    name: 'Under Secretary for Farm and Foreign Agricultural Services',
+                    toptier_name: USDA,
+                },
+                {
+                    ...baseSubAgency,
+                    name: 'Federal Emergency Management Agency',
+                    toptier_name: DHS,
+                },
+                {
+                    ...baseSubAgency,
                     name: 'National Oceanic and Atmospheric Administration',
-                },
-                {
-                    ...baseAgency,
-                    name: 'Energy Efficiency and Renewable Energy',
-                },
-                { ...baseAgency, name: 'Indian Health Service' },
-                { ...baseAgency, name: 'Nuclear Energy' },
-                {
-                    ...baseAgency,
-                    name: 'United States Fish and Wildlife Service',
-                },
-                {
-                    ...baseAgency,
-                    name: 'Environmental Programs and Management',
-                },
-                { ...baseAgency, name: 'United States Geological Survey' },
-                {
-                    ...baseAgency,
-                    name: 'Office of the Secretary',
-                    toptier_name: 'Department of Interior',
+                    toptier_name: COMMERCE,
                 },
             ];
         case Category.CIVIL_WORKS:
             return [
-                { ...baseAgency, name: 'Corps of Engineers - Civil Works' },
+                { ...baseTopAgency, name: 'Department of Defense' },
+                { ...baseTopAgency, name: 'General Services Administration' },
+                { ...baseTopAgency, name: 'Corps of Engineers - Civil Works' },
+                {
+                    ...baseSubAgency,
+                    name: 'U.S. Customs and Border Protection',
+                    toptier_name: DHS,
+                },
             ];
         case Category.TRANSPORTATION:
-            return [
-                { ...baseAgency, name: 'Federal Aviation Administration' },
-                { ...baseAgency, name: 'Federal Highway Administration' },
-                { ...baseAgency, name: 'Federal Transit Administration' },
-                { ...baseAgency, name: 'Real Property Activities' },
-                { ...baseAgency, name: 'Maritime Administration' },
-                {
-                    ...baseAgency,
-                    name: 'Office of the Secretary',
-                    toptier_name: 'Department of Transportation',
-                },
-                {
-                    ...baseAgency,
-                    name: 'Federal Motor Carrier Safety Administration',
-                },
-                {
-                    ...baseAgency,
-                    name: 'Energy Efficiency and Renewable Energy',
-                }, // electric vehicles
-            ];
+            return [{ ...baseTopAgency, name: 'Department of Transportation' }];
         case Category.BROADBAND:
             return [
-                { ...baseAgency, name: 'Rural Utilities Service' },
                 {
-                    ...baseAgency,
+                    ...baseSubAgency,
+                    name: 'Rural Utilities Service',
+                    toptier_name: USDA,
+                },
+                {
+                    ...baseSubAgency,
+                    name: 'National Institute of Standards and Technology',
+                    toptier_name: COMMERCE,
+                },
+                {
+                    ...baseSubAgency,
                     name: 'National Telecommunications and Information Administration',
+                    toptier_name: COMMERCE,
                 },
             ];
         case Category.OTHER:
             return [
-                { ...baseAgency, name: 'Denali Commission' },
+                { ...baseTopAgency, name: 'Department of Education' }, // none yet
                 {
-                    ...baseAgency,
+                    ...baseTopAgency,
+                    name: 'Department of Housing and Urban Development',
+                }, // none yet
+                { ...baseTopAgency, name: 'Department of Justice' }, // none yet
+                { ...baseTopAgency, name: 'Department of Labor' }, // none yet
+                { ...baseTopAgency, name: 'Department of State' }, // none yet
+                { ...baseTopAgency, name: 'Department of the Treasury' },
+                { ...baseTopAgency, name: 'Department of Veterans Affairs' }, // none yet
+                { ...baseTopAgency, name: 'Executive Office of the President' },
+                {
+                    ...baseSubAgency,
                     name: 'Office of the Secretary',
-                    toptier_name: 'Department of Agriculture',
+                    toptier_name: USDA,
                 },
-                { ...baseAgency, name: 'Delta Regional Authority' },
+                { ...baseTopAgency, name: 'Delta Regional Authority' },
+                {
+                    ...baseSubAgency,
+                    name: 'Office of Procurement Services',
+                    toptier_name: DHS,
+                },
+                { ...baseTopAgency, name: 'Denali Commission' },
             ];
     }
 }
 
 export function getCategoryForAgencies(agencies: Agency[]): Category {
     const anAgencyInEachCategory: Record<string, Category> = {
-        'Bureau of Reclamation': Category.CLIMATE,
-        'Corps of Engineers - Civil Works': Category.CIVIL_WORKS,
-        'Federal Aviation Administration': Category.TRANSPORTATION,
+        'Department of Energy': Category.CLIMATE,
+        'Department of Defense': Category.CIVIL_WORKS,
+        'Department of Transportation': Category.TRANSPORTATION,
         'Rural Utilities Service': Category.BROADBAND,
         'Denali Commission': Category.OTHER,
     };


### PR DESCRIPTION
## Overview
[Restore CIVIL_WORKS category and improve agency lookup](https://github.com/azavea/green-equity-demo/commit/8667fcaa1fd79ba96b76bcb7d0e435b2e3ca0ec4)
[Make last updated date dynamic](https://github.com/azavea/green-equity-demo/commit/c2c5402db09590db9508d40c951356cae9dec1f9)
[Remove references to announced funding](https://github.com/azavea/green-equity-demo/commit/997d87cf1574a5203154d0579d4e43c6941930ec)
[Create category for all spending](https://github.com/azavea/green-equity-demo/commit/bd88774cee0fbd43846a906f1f32ab96532048db)

Closes #50

### Demo
<img width="390" alt="Screenshot 2023-03-03 at 2 17 06 PM" src="https://user-images.githubusercontent.com/38668450/222813527-b0c18a43-9ce6-43c9-96a7-633cbfae00ad.png">



### Notes
The "all categories" spending wasn't passed to the SpendingTooltip, so the denominator was wrong. Decided to create an ALL category to track this.

While here, noticed that I didn't implement the dynamic last date updated in #49.

While here, I noticed that some agencies didn't actually exist; they related to "announced" data (which we're not handling), so I validated this against the GSA dashboard and refactored/simplified the agency handling. The sums of the categories are now much closer to 100%.

## Testing Instructions

- delete data in src/app/data
- update
- server
- View map tooltips

 ## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
