### PR TITLE
Add additional lato font weights for Chakra UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add spending and state data fetching scripts [#40](https://github.com/azavea/green-equity-demo/pull/40)
 - Add Github Pages deploy to CI workflow [#48](https://github.com/azavea/green-equity-demo/pull/48)
 - Add data attribution section [#49](https://github.com/azavea/green-equity-demo/pull/49)
+- Add additional lato font weights for Chakra UI [#55](https://github.com/azavea/green-equity-demo/pull/55)
 
 ### Changed
 

--- a/src/app/src/index.tsx
+++ b/src/app/src/index.tsx
@@ -13,7 +13,9 @@ import App from './App';
 import theme from './theme';
 import { store } from './store';
 
-import '@fontsource/lato';
+import '@fontsource/lato/400.css';
+import '@fontsource/lato/700.css';
+
 import '../node_modules/leaflet/dist/leaflet.css';
 
 import './index.css';


### PR DESCRIPTION
## Overview

This PR adds imports for Lato font weights 400 and 700. These are required by Chakra UI. Though some browsers appear to be okay without the 700 weight font, in Safari they can appear a bit off.

Closes #43 

### Notes

I included all the font weight imports, but the compiled bundle pulled in only 400 and 700 so I left just these two. I left the others out because I think they increase the bundle size (though not by much, it's not the fonts themselves, just the css imports).

## Testing Instructions

- http://localhost:8765/ in Safari
  - [x] Ensure Lato font displays properly, check especially "Data Sandbox" button text

 ## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
