### PR TITLE
Show only selected category in tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Use Closes # in PR template [#9](https://github.com/azavea/green-equity-demo/pull/9)
 -   Change map to Albers USA projection [#31](https://github.com/azavea/green-equity-demo/pull/31)
 -   Place state markers at the points farthest from edges [#45](https://github.com/azavea/green-equity-demo/pull/45)
+-   Show only selected category data in tooltip [#61](https://github.com/azavea/green-equity-demo/pull/61)
 
 ### Fixed
 

--- a/src/app/src/components/PerCapitaMap.tsx
+++ b/src/app/src/components/PerCapitaMap.tsx
@@ -248,9 +248,6 @@ function StatesAndMarkersLayer({
                         const perCapitaSpending = stateSpending?.per_capita;
 
                         if (!perCapitaSpending) {
-                            console.warn(
-                                `No spending data for state: ${feature.properties.STUSPS}`
-                            );
                             return;
                         }
 

--- a/src/app/src/components/PerCapitaMap.tsx
+++ b/src/app/src/components/PerCapitaMap.tsx
@@ -134,7 +134,7 @@ export default function PerCapitaMap() {
                     <StatesAndMarkersLayer
                         allSpending={data.results}
                         spendingByCategoryByState={spendingByCategoryByState}
-                        categoryForMarker={spendingCategory}
+                        selectedCategory={spendingCategory}
                     />
                 ) : (
                     <Center p={4}>
@@ -150,14 +150,14 @@ export default function PerCapitaMap() {
 function StatesAndMarkersLayer({
     allSpending,
     spendingByCategoryByState,
-    categoryForMarker,
+    selectedCategory,
 }: {
     allSpending: SpendingByGeographySingleResult[];
     spendingByCategoryByState: Map<
         String,
         Map<Category, SpendingByGeographySingleResult | undefined>
     >;
-    categoryForMarker: Category;
+    selectedCategory: Category;
 }) {
     const map = useMap();
     const markerReference = useRef<L.Marker[]>([]);
@@ -230,11 +230,11 @@ function StatesAndMarkersLayer({
                             state={allStateSpending.display_name ?? ''}
                             stateCode={allStateSpending.shape_code ?? ''}
                             population={allStateSpending.population ?? 0}
-                            dollarsPerCapita={allStateSpending.per_capita ?? 0}
                             allSpending={
                                 allStateSpending.aggregated_amount ?? 0
                             }
                             spendingByCategory={spendingByCategory}
+                            selectedCategory={selectedCategory}
                         />,
                         tooltip
                     );
@@ -244,7 +244,7 @@ function StatesAndMarkersLayer({
                     layer.on('add', event => {
                         const stateSpending = spendingByCategoryByState
                             .get(feature.properties.STUSPS)
-                            ?.get(categoryForMarker);
+                            ?.get(selectedCategory);
                         const perCapitaSpending = stateSpending?.per_capita;
 
                         if (!perCapitaSpending) {


### PR DESCRIPTION
## Overview
Show only data for the selected category in the spending tooltip.

Closes #59

### Demo
<img width="303" alt="Screenshot 2023-03-06 at 1 15 30 PM" src="https://user-images.githubusercontent.com/38668450/223195853-64776cd8-5e3a-45b9-b0dd-cf254d3b8885.png">

## Testing Instructions

- server
- Toggle categories, view tooltips

 ## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [ ] CI passes after rebase
