### PR TITLE
Add leftover percent to other category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ and this project adheres to
     [#62](https://github.com/azavea/green-equity-demo/pull/62)
 -   Convert per-capita map to choropleth
     [#69](https://github.com/azavea/green-equity-demo/pull/69)
+-   Make other category remainder of spending
+    [#71](https://github.com/azavea/green-equity-demo/pull/71)
 
 ### Fixed
 

--- a/src/app/dataScripts/fetchAgencyData.ts
+++ b/src/app/dataScripts/fetchAgencyData.ts
@@ -1,0 +1,146 @@
+import fs from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+import { spendingApiUrl } from '../src/constants';
+
+import { dataDir } from './nodeConstants';
+import httpsRequest from './httpsRequest';
+
+type TopTierAgency = {
+    name: string;
+    toptier_agency_id: number;
+    toptier_code: string;
+};
+
+type TopTierAgencies = {
+    agencies: {
+        cfo_agencies: TopTierAgency[];
+        other_agencies: TopTierAgency[];
+    };
+};
+
+type SubAgency = {
+    name: string;
+    abbreviation: string;
+    total_obligations: number;
+    transaction_count: number;
+    new_award_count: number;
+    children?: SubAgency[];
+};
+
+type TopTierAgencySubAgencies = {
+    page_metadata: {
+        page: number;
+        total: number;
+        limit: number;
+        next: number;
+        previous: number;
+        hasNext: boolean;
+        hasPrevious: boolean;
+    };
+    results: SubAgency[];
+};
+
+async function fetchAgencyData() {
+    console.log('Fetching agency data...');
+
+    await fetchTopTeirAgencies().then(fetchSubAgencies);
+}
+
+async function fetchTopTeirAgencies(): Promise<TopTierAgencies> {
+    const filename = path.join(dataDir, 'topTierAgencies.json');
+
+    if (existsSync(filename)) {
+        console.warn(
+            ' Skipping top tier agency data because the file already exists.'
+        );
+
+        return await fs
+            .readFile(filename)
+            .then(buffer => JSON.parse(buffer.toString()));
+    }
+
+    const fileHandle = await fs.open(filename, 'w');
+
+    const data = await httpsRequest<TopTierAgencies>({
+        url: `${spendingApiUrl}/bulk_download/list_agencies`,
+        options: { method: 'POST' },
+        body: JSON.stringify({ type: 'award_agencies' }),
+    });
+
+    await fileHandle.write(JSON.stringify(data));
+    await fileHandle.close();
+
+    return data;
+}
+
+async function fetchSubAgencies(topTierAgencies: TopTierAgencies) {
+    const filename = path.join(dataDir, 'subAgencies.json');
+
+    if (existsSync(filename)) {
+        console.warn(
+            ' Skipping subagency data because the file already exists.'
+        );
+        return;
+    }
+
+    await Promise.all(
+        [
+            ...topTierAgencies.agencies.cfo_agencies,
+            ...topTierAgencies.agencies.other_agencies,
+        ].map(fetchSubAgenciesForTopTierAgency)
+    )
+        .then(filterEmptyTopTierAgencies)
+        .then(mergeSubAgencies)
+        .then(writeSubAgencies(filename))
+        .catch(console.error);
+}
+
+async function fetchSubAgenciesForTopTierAgency(topTierAgency: TopTierAgency) {
+    console.log(`  Fetching sub agencies for ${topTierAgency.name}`);
+
+    let data: TopTierAgencySubAgencies | undefined;
+    let page = 1;
+    const results: SubAgency[] = [];
+
+    do {
+        try {
+            data = await httpsRequest<TopTierAgencySubAgencies>({
+                url: `${spendingApiUrl}/agency/${topTierAgency.toptier_code}/sub_agency/?page=${page}&limit=100`,
+            });
+
+            if (data?.results) {
+                results.push(...data.results);
+            }
+        } catch (error) {
+            data = undefined;
+            console.error(error);
+        } finally {
+            page += 1;
+        }
+    } while (data?.page_metadata?.hasNext);
+
+    return results;
+}
+
+async function filterEmptyTopTierAgencies(subAgencies: SubAgency[][]) {
+    return subAgencies.filter(subAgencies => subAgencies.length > 0);
+}
+
+async function mergeSubAgencies(subAgencies: SubAgency[][]) {
+    return subAgencies.flatMap(subAgencies =>
+        subAgencies.flatMap(({ children, ...subAgency }) => [
+            subAgency,
+            ...(children ?? []),
+        ])
+    );
+}
+
+function writeSubAgencies(filename: string) {
+    return async (subAgencies: SubAgency[]) => {
+        fs.writeFile(filename, JSON.stringify(subAgencies));
+    };
+}
+
+fetchAgencyData();

--- a/src/app/dataScripts/fetchPerCapitaSpendingData.ts
+++ b/src/app/dataScripts/fetchPerCapitaSpendingData.ts
@@ -11,7 +11,7 @@ import {
 } from '../src/util';
 
 import { dataDir } from './nodeConstants';
-import httpsRequestToCallback from './httpsRequestToCallback';
+import httpsRequest from './httpsRequest';
 
 export default async function fetchPerCapitaSpendingData() {
     console.log('Fetching per-capita spending data...');
@@ -43,15 +43,15 @@ async function writeSpendingDataFile(category: Category) {
     }
 
     return fs.open(filename, 'w').then(async fileHandle => {
-        await httpsRequestToCallback({
+        const data = await httpsRequest({
             url: `${spendingApiUrl}/search/spending_by_geography/`,
             options: {
                 method: 'POST',
             },
             body: JSON.stringify(requestBody),
-            onDataResponse: data => fileHandle.write(JSON.stringify(data)),
         });
 
-        fileHandle.close();
+        await fileHandle.write(JSON.stringify(data));
+        await fileHandle.close();
     });
 }

--- a/src/app/dataScripts/fetchSpendingOverTimeData.ts
+++ b/src/app/dataScripts/fetchSpendingOverTimeData.ts
@@ -13,7 +13,7 @@ import {
 } from '../src/types/api';
 
 import { dataDir, statesJSON } from './nodeConstants';
-import httpsRequestToCallback from './httpsRequestToCallback';
+import httpsRequest from './httpsRequest';
 
 export default async function fetchSpendingOverTimeData() {
     console.log('Fetching spending over time data for each state...');
@@ -67,21 +67,23 @@ export default async function fetchSpendingOverTimeData() {
     });
 }
 
-async function fetchSpendingData(state: string, responseCallback: any) {
+async function fetchSpendingData(
+    state: string,
+    responseCallback: (data: any) => void
+) {
     console.log(`Fetching ${state} spending.`);
 
     const requestBody = getSpendingOverTimeByStateRequest();
 
     requestBody.filters.place_of_performance_locations[0]!.state = state;
 
-    return await httpsRequestToCallback({
+    return await httpsRequest({
         url: `${spendingApiUrl}/search/spending_over_time/`,
         options: {
             method: 'POST',
         },
         body: JSON.stringify(requestBody),
-        onDataResponse: responseCallback,
-    });
+    }).then(responseCallback);
 }
 
 function cleanDataDump(

--- a/src/app/dataScripts/fetchStatesData.ts
+++ b/src/app/dataScripts/fetchStatesData.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { spendingApiUrl } from '../src/constants';
 
 import { dataDir } from './nodeConstants';
-import httpsRequestToCallback from './httpsRequestToCallback';
+import httpsRequest from './httpsRequest';
 
 export default async function fetchStatesData() {
     console.log('Fetching state data...');
@@ -18,11 +18,11 @@ export default async function fetchStatesData() {
     }
 
     await fs.open(filename, 'w').then(async fileHandle => {
-        await httpsRequestToCallback({
+        const data = await httpsRequest({
             url: `${spendingApiUrl}/recipient/state/`,
-            onDataResponse: data => fileHandle.write(JSON.stringify(data)),
         });
 
-        fileHandle.close();
+        await fileHandle.write(JSON.stringify(data));
+        await fileHandle.close();
     });
 }

--- a/src/app/dataScripts/httpsRequest.ts
+++ b/src/app/dataScripts/httpsRequest.ts
@@ -1,16 +1,14 @@
 import https from 'node:https';
 
-export default function httpsRequestToCallback({
+export default function httpsRequest<T>({
     url,
     options = {},
     body,
-    onDataResponse,
 }: {
     url: string;
     options?: https.RequestOptions;
     body?: string;
-    onDataResponse: (parsedResult: any) => void;
-}): Promise<void> {
+}): Promise<T> {
     return new Promise((resolve, reject) => {
         const request = https.request(
             url,
@@ -30,8 +28,7 @@ export default function httpsRequestToCallback({
                 });
 
                 response.on('end', () => {
-                    onDataResponse(JSON.parse(completeData));
-                    resolve();
+                    resolve(JSON.parse(completeData));
                 });
             }
         );

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -48,7 +48,8 @@
     "start": "craco start",
     "build": "craco build",
     "test": "craco test",
-    "fetch-data": "ts-node dataScripts/fetchData.ts"
+    "fetch-data": "ts-node dataScripts/fetchData.ts",
+    "fetch-data:agency": "ts-node dataScripts/fetchAgencyData.ts"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/src/app/src/components/PerCapitaMap/PerCapitaMapLegend.tsx
+++ b/src/app/src/components/PerCapitaMap/PerCapitaMapLegend.tsx
@@ -28,7 +28,7 @@ export default function PerCapitaMapLegend() {
                             : `$${category.min.toLocaleString()}+`;
 
                         return (
-                            <VStack flex={1}>
+                            <VStack flex={1} key={category.min}>
                                 <Box
                                     height={isMobileMode ? '20px' : '30px'}
                                     width='100%'

--- a/src/app/src/components/PerCapitaMap/SpendingTooltip.tsx
+++ b/src/app/src/components/PerCapitaMap/SpendingTooltip.tsx
@@ -12,10 +12,11 @@ import {
     Text,
     Progress,
 } from '@chakra-ui/react';
+import { createPortal } from 'react-dom';
+
 import { Category, isCategory } from '../../enums';
 import { abbreviateNumber } from '../../util';
-import { SpendingByGeographySingleResult } from '../../types/api';
-import { createPortal } from 'react-dom';
+import { StateSpending } from '../../types/api';
 
 export default function SpendingTooltip({
     state,
@@ -26,7 +27,7 @@ export default function SpendingTooltip({
 }: {
     state: string;
     population: number;
-    spendingByCategory: Record<Category, SpendingByGeographySingleResult>;
+    spendingByCategory: StateSpending;
     selectedCategory: Category;
     tooltipDiv: HTMLDivElement | undefined;
 }) {
@@ -80,9 +81,9 @@ export default function SpendingTooltip({
 function SpendingBars({
     spendingByCategory,
 }: {
-    spendingByCategory: Record<Category, SpendingByGeographySingleResult>;
+    spendingByCategory: StateSpending;
 }) {
-    const totalAmount = spendingByCategory[Category.ALL].aggregated_amount;
+    const totalAmount = spendingByCategory[Category.ALL]!.aggregated_amount;
     let leftoverPercent = 100;
 
     return (

--- a/src/app/src/components/PerCapitaMap/SpendingTooltip.tsx
+++ b/src/app/src/components/PerCapitaMap/SpendingTooltip.tsx
@@ -67,34 +67,9 @@ export default function SpendingTooltip({
                             Population: {abbreviateNumber(population)}
                         </Text>
                     </Box>
-                    <Box>
-                        {selectedCategory === Category.ALL &&
-                            Object.entries(spendingByCategory).map(
-                                ([cat, result]) => {
-                                    if (!isCategory(cat)) {
-                                        throw new Error('Unreachable code');
-                                    }
-
-                                    if (cat === Category.ALL) {
-                                        return null;
-                                    }
-
-                                    const amount = result.aggregated_amount;
-
-                                    return (
-                                        <SpendingBar
-                                            key={`tooltipCategory-${state}-${cat.toString()}`}
-                                            cat={cat}
-                                            amount={amount}
-                                            allSpending={
-                                                spendingByCategory[Category.ALL]
-                                                    .aggregated_amount
-                                            }
-                                        />
-                                    );
-                                }
-                            )}
-                    </Box>
+                    {selectedCategory === Category.ALL ? (
+                        <SpendingBars spendingByCategory={spendingByCategory} />
+                    ) : null}
                 </Stack>
             </CardBody>
         </Card>,
@@ -102,25 +77,48 @@ export default function SpendingTooltip({
     );
 }
 
-function SpendingBar({
-    cat,
-    amount,
-    allSpending,
+function SpendingBars({
+    spendingByCategory,
 }: {
-    cat: Category;
-    amount: number;
-    allSpending: number;
+    spendingByCategory: Record<Category, SpendingByGeographySingleResult>;
 }) {
+    const totalAmount = spendingByCategory[Category.ALL].aggregated_amount;
+    let leftoverPercent = 100;
+
+    return (
+        <Box>
+            {Object.entries(spendingByCategory).map(([cat, result]) => {
+                if (!isCategory(cat)) {
+                    throw new Error('Unreachable code');
+                }
+
+                if (cat === Category.ALL || cat === Category.OTHER) {
+                    return null;
+                }
+
+                const percent = roundedPercent(
+                    result.aggregated_amount,
+                    totalAmount
+                );
+
+                leftoverPercent -= percent;
+
+                return <SpendingBar key={cat} cat={cat} percent={percent} />;
+            })}
+            <SpendingBar
+                cat={Category.OTHER}
+                percent={Math.max(leftoverPercent, 0)}
+            />
+        </Box>
+    );
+}
+
+function SpendingBar({ cat, percent }: { cat: Category; percent: number }) {
     return (
         <>
             <Text>{cat.toString()}:</Text>
-            <Text>{roundedPercent(amount, allSpending)}%</Text>
-            <Progress
-                mb={2}
-                colorScheme='tooltip'
-                size='lg'
-                value={roundedPercent(amount, allSpending)}
-            />
+            <Text>{percent}%</Text>
+            <Progress mb={2} colorScheme='tooltip' size='lg' value={percent} />
         </>
     );
 }

--- a/src/app/src/components/PerCapitaMap/useSpendingByCategoryByState.tsx
+++ b/src/app/src/components/PerCapitaMap/useSpendingByCategoryByState.tsx
@@ -1,6 +1,6 @@
 import { useGetStatesQuery, useGetSpendingByGeographyQuery } from '../../api';
 import { Category, isCategory } from '../../enums';
-import { SpendingByGeographySingleResult } from '../../types/api';
+import { StateSpending } from '../../types/api';
 import {
     getDefaultSpendingByGeographyRequest,
     getAgenciesForCategory,
@@ -15,7 +15,6 @@ export default function useSpendingByCategoryByState() {
         [Category.CIVIL_WORKS]: useCategoryData(Category.CIVIL_WORKS),
         [Category.CLIMATE]: useCategoryData(Category.CLIMATE),
         [Category.TRANSPORTATION]: useCategoryData(Category.TRANSPORTATION),
-        [Category.OTHER]: useCategoryData(Category.OTHER),
     };
 
     if (!states) {
@@ -49,10 +48,7 @@ export default function useSpendingByCategoryByState() {
             return spendingByCategoryByState;
         },
         Object.fromEntries(
-            states.map(state => [
-                state.code,
-                {} as Record<Category, SpendingByGeographySingleResult>,
-            ])
+            states.map(state => [state.code, {} as StateSpending])
         )
     );
 }

--- a/src/app/src/types/api.d.ts
+++ b/src/app/src/types/api.d.ts
@@ -46,6 +46,8 @@ export type SpendingByGeographyResponse = {
     results: SpendingByGeographySingleResult[];
 };
 
+export type StateSpending = Record<Category, SpendingByGeographySingleResult>;
+
 export type SpendingOverTimeByStateRequest = {
     filters: {
         def_codes: DefCode[];


### PR DESCRIPTION
## Overview

This PR adds fetch scripts for agency data. Originally, I was going to use this data to automatically generate categories for sub-agencies based on their top-tier agency. This ended up being pretty complex and probably not worth the payoff of rounding out the tooltip percentages. I left the scripts in in case we want them later. Instead of using that data, I made the other category show the remaining percentage.

Closes #64 

## Testing Instructions

- http://localhost:8765/
  - [x] Ensure tooltip category percentages add to 100

 ## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
