### PR TITLE
Reposition animated spending bucket over DC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,5 +71,7 @@ and this project adheres to
     [#54](https://github.com/azavea/green-equity-demo/pull/54)
 -   Fix various minor things
     [#84](https://github.com/azavea/green-equity-demo/pull/84)
+-   Reposition animated spending bucket over DC
+    [#85](https://github.com/azavea/green-equity-demo/pull/85)
 
 ### Removed

--- a/src/app/src/components/AnimatedArcsAndMap/AnimatedArcsAndMap.tsx
+++ b/src/app/src/components/AnimatedArcsAndMap/AnimatedArcsAndMap.tsx
@@ -72,7 +72,7 @@ export default function AnimatedArcsAndMap() {
                 Allocation of awarded funding over time
             </Heading>
             <Spacer></Spacer>
-            {data && !isFetching ? (
+            {data && spendingAtTimeByState && !isFetching ? (
                 <>
                     <AnimatedMapLegend />
                     <UsaMapContainer>
@@ -81,7 +81,7 @@ export default function AnimatedArcsAndMap() {
                         />
                         <AnimatedMap
                             animationEnabled={animationEnabled}
-                            spendingAtTimeByState={spendingAtTimeByState!}
+                            spendingAtTimeByState={spendingAtTimeByState}
                         />
                     </UsaMapContainer>
                     <Box width='100%' textAlign={'center'}>

--- a/src/app/src/components/AnimatedArcsAndMap/AnimatedArcsAndMap.tsx
+++ b/src/app/src/components/AnimatedArcsAndMap/AnimatedArcsAndMap.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import {
     Center,
     CircularProgress,
@@ -16,10 +17,10 @@ import TimeControlIcon from './TimeControlIcon';
 
 import AnimatedMap from './AnimatedMap';
 import AnimatedMapLegend from './AnimatedMapLegend';
-import AnimatedTotalSpendingBucket from './AnimatedTotalSpendingBucket';
 import { useGetSpendingOverTimeQuery } from '../../api';
 import { getSpendingByStateAtTime, PROGRESS_FINAL_STEP } from '../../util';
 import { MONTHLY_TIME_DURATION } from '../../constants';
+import AnimatedTotalSpendingBucket from './AnimatedTotalSpendingBucket';
 
 export default function AnimatedArcsAndMap() {
     const { data, isFetching } = useGetSpendingOverTimeQuery();
@@ -30,6 +31,7 @@ export default function AnimatedArcsAndMap() {
     );
     const [animationEnabled, setAnimationEnabled] = useState(false);
     const [restartTimeControl, setRestartTimeControl] = useState(false);
+    const spendingBucketContainerRef = useRef<Element | undefined>();
 
     useEffect(() => {
         timeValue % 1 === 0 &&
@@ -72,16 +74,24 @@ export default function AnimatedArcsAndMap() {
                 Allocation of awarded funding over time
             </Heading>
             <Spacer></Spacer>
-            {data && spendingAtTimeByState && !isFetching ? (
+            {data && !isFetching ? (
                 <>
                     <AnimatedMapLegend />
-                    <UsaMapContainer>
-                        <AnimatedTotalSpendingBucket
-                            spendingAtTimeByState={spendingAtTimeByState}
-                        />
+                    <UsaMapContainer containerRef={spendingBucketContainerRef}>
+                        <>
+                            {spendingBucketContainerRef.current &&
+                                createPortal(
+                                    <AnimatedTotalSpendingBucket
+                                        spendingAtTimeByState={
+                                            spendingAtTimeByState
+                                        }
+                                    />,
+                                    spendingBucketContainerRef.current
+                                )}
+                        </>
                         <AnimatedMap
                             animationEnabled={animationEnabled}
-                            spendingAtTimeByState={spendingAtTimeByState}
+                            spendingAtTimeByState={spendingAtTimeByState!}
                         />
                     </UsaMapContainer>
                     <Box width='100%' textAlign={'center'}>

--- a/src/app/src/components/AnimatedArcsAndMap/AnimatedArcsAndMap.tsx
+++ b/src/app/src/components/AnimatedArcsAndMap/AnimatedArcsAndMap.tsx
@@ -1,5 +1,4 @@
-import { useEffect, useState, useRef } from 'react';
-import { createPortal } from 'react-dom';
+import { useEffect, useState } from 'react';
 import {
     Center,
     CircularProgress,
@@ -31,7 +30,6 @@ export default function AnimatedArcsAndMap() {
     );
     const [animationEnabled, setAnimationEnabled] = useState(false);
     const [restartTimeControl, setRestartTimeControl] = useState(false);
-    const spendingBucketContainerRef = useRef<Element | undefined>();
 
     useEffect(() => {
         timeValue % 1 === 0 &&
@@ -77,18 +75,10 @@ export default function AnimatedArcsAndMap() {
             {data && !isFetching ? (
                 <>
                     <AnimatedMapLegend />
-                    <UsaMapContainer containerRef={spendingBucketContainerRef}>
-                        <>
-                            {spendingBucketContainerRef.current &&
-                                createPortal(
-                                    <AnimatedTotalSpendingBucket
-                                        spendingAtTimeByState={
-                                            spendingAtTimeByState
-                                        }
-                                    />,
-                                    spendingBucketContainerRef.current
-                                )}
-                        </>
+                    <UsaMapContainer>
+                        <AnimatedTotalSpendingBucket
+                            spendingAtTimeByState={spendingAtTimeByState}
+                        />
                         <AnimatedMap
                             animationEnabled={animationEnabled}
                             spendingAtTimeByState={spendingAtTimeByState!}

--- a/src/app/src/components/AnimatedArcsAndMap/AnimatedMap.tsx
+++ b/src/app/src/components/AnimatedArcsAndMap/AnimatedMap.tsx
@@ -23,7 +23,8 @@ export default function AnimatedMap({
     const createArcPath = useCreateArcPath(arcPathsReference);
 
     useEffect(() => {
-        map &&
+        spendingAtTimeByState &&
+            map &&
             map.eachLayer(l => {
                 const asGeoJson = l as L.GeoJSON<
                     StateProperties,

--- a/src/app/src/components/AnimatedArcsAndMap/AnimatedMap.tsx
+++ b/src/app/src/components/AnimatedArcsAndMap/AnimatedMap.tsx
@@ -23,8 +23,7 @@ export default function AnimatedMap({
     const createArcPath = useCreateArcPath(arcPathsReference);
 
     useEffect(() => {
-        spendingAtTimeByState &&
-            map &&
+        map &&
             map.eachLayer(l => {
                 const asGeoJson = l as L.GeoJSON<
                     StateProperties,

--- a/src/app/src/components/AnimatedArcsAndMap/AnimatedTotalSpendingBucket.tsx
+++ b/src/app/src/components/AnimatedArcsAndMap/AnimatedTotalSpendingBucket.tsx
@@ -7,7 +7,7 @@ import { TOTAL_BIL_AMOUNT } from '../../constants';
 export default function AnimatedTotalSpendingBucket({
     spendingAtTimeByState,
 }: {
-    spendingAtTimeByState: SpendingByGeographyAtMonth;
+    spendingAtTimeByState: SpendingByGeographyAtMonth | undefined;
 }) {
     const [totalSpendingAtTime, setTotalSpendingAtTime] = useState(0);
 
@@ -26,12 +26,7 @@ export default function AnimatedTotalSpendingBucket({
     const amountLeft = TOTAL_BIL_AMOUNT - totalSpendingAtTime;
 
     return (
-        <Tag
-            background='none'
-            className={'leaflet-bottom'}
-            position={'absolute'}
-            right={'60'}
-        >
+        <Tag background='none'>
             <Progress
                 value={amountLeft}
                 opacity={100}

--- a/src/app/src/components/AnimatedArcsAndMap/AnimatedTotalSpendingBucket.tsx
+++ b/src/app/src/components/AnimatedArcsAndMap/AnimatedTotalSpendingBucket.tsx
@@ -26,7 +26,7 @@ export default function AnimatedTotalSpendingBucket({
     const amountLeft = TOTAL_BIL_AMOUNT - totalSpendingAtTime;
 
     return (
-        <Tag background='none'>
+        <Tag background='none' paddingLeft={0}>
             <Progress
                 value={amountLeft}
                 opacity={100}

--- a/src/app/src/components/AnimatedArcsAndMap/AnimatedTotalSpendingBucket.tsx
+++ b/src/app/src/components/AnimatedArcsAndMap/AnimatedTotalSpendingBucket.tsx
@@ -1,14 +1,34 @@
 import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Progress, Tag, TagLabel } from '@chakra-ui/react';
+import { useMap } from 'react-leaflet';
+import L from 'leaflet';
 
 import { SpendingByGeographyAtMonth } from '../../types/api';
-import { TOTAL_BIL_AMOUNT } from '../../constants';
+import { DC_CENTER, TOTAL_BIL_AMOUNT } from '../../constants';
 
 export default function AnimatedTotalSpendingBucket({
     spendingAtTimeByState,
 }: {
     spendingAtTimeByState: SpendingByGeographyAtMonth | undefined;
 }) {
+    const map = useMap();
+    const [div, setDiv] = useState<HTMLDivElement | undefined>();
+
+    useEffect(() => {
+        const div = document.createElement('div');
+        L.popup({ className: 'portal-container', closeButton: false })
+            .setLatLng(DC_CENTER)
+            .setContent(div)
+            .openOn(map);
+
+        setDiv(div);
+
+        return () => {
+            setDiv(undefined);
+        };
+    }, [map]);
+
     const [totalSpendingAtTime, setTotalSpendingAtTime] = useState(0);
 
     useEffect(() => {
@@ -25,7 +45,11 @@ export default function AnimatedTotalSpendingBucket({
 
     const amountLeft = TOTAL_BIL_AMOUNT - totalSpendingAtTime;
 
-    return (
+    if (!div) {
+        return null;
+    }
+
+    return createPortal(
         <Tag background='none' paddingLeft={0}>
             <Progress
                 value={amountLeft}
@@ -46,7 +70,8 @@ export default function AnimatedTotalSpendingBucket({
             >
                 ${divideByBillion(amountLeft)}B
             </TagLabel>
-        </Tag>
+        </Tag>,
+        div
     );
 }
 

--- a/src/app/src/components/UsaMapContainer.tsx
+++ b/src/app/src/components/UsaMapContainer.tsx
@@ -1,15 +1,18 @@
 import { useBreakpointValue } from '@chakra-ui/react';
 import { ReactNode, useEffect } from 'react';
 import { MapContainer, useMap } from 'react-leaflet';
+import L from 'leaflet';
 
-import { MAP_CONTAINER_NEGATIVE_MARGIN } from '../constants';
+import { MAP_CONTAINER_NEGATIVE_MARGIN, DC_CENTER } from '../constants';
 
 export default function UsaMapContainer({
     negativeMargin = false,
     children,
+    containerRef,
 }: {
     negativeMargin?: boolean;
     children?: ReactNode;
+    containerRef?: React.MutableRefObject<Element | undefined>;
 }) {
     const startingZoom = useMapZoom();
 
@@ -38,6 +41,7 @@ export default function UsaMapContainer({
             }}
         >
             <MobileZoomer />
+            <PortalContainerSetter containerRef={containerRef} />
             {children}
         </MapContainer>
     );
@@ -62,4 +66,19 @@ function useMapZoom() {
             md: 4.5,
         }) ?? 4.5
     );
+}
+
+function PortalContainerSetter({
+    containerRef,
+}: {
+    containerRef?: React.MutableRefObject<Element | undefined>;
+}) {
+    const map = useMap();
+    if (containerRef && !containerRef.current) {
+        // Create container div for spending bucket animation
+        const popupContainer = document.createElement('div');
+        L.popup().setLatLng(DC_CENTER).setContent(popupContainer).openOn(map);
+        containerRef.current = popupContainer;
+    }
+    return null;
 }

--- a/src/app/src/components/UsaMapContainer.tsx
+++ b/src/app/src/components/UsaMapContainer.tsx
@@ -77,7 +77,10 @@ function PortalContainerSetter({
     if (containerRef && !containerRef.current) {
         // Create container div for spending bucket animation
         const popupContainer = document.createElement('div');
-        L.popup().setLatLng(DC_CENTER).setContent(popupContainer).openOn(map);
+        L.popup({ className: 'portal-container', closeButton: false })
+            .setLatLng(DC_CENTER)
+            .setContent(popupContainer)
+            .openOn(map);
         containerRef.current = popupContainer;
     }
     return null;

--- a/src/app/src/components/UsaMapContainer.tsx
+++ b/src/app/src/components/UsaMapContainer.tsx
@@ -1,9 +1,8 @@
 import { useBreakpointValue } from '@chakra-ui/react';
 import { ReactNode, useEffect } from 'react';
 import { MapContainer, useMap } from 'react-leaflet';
-import L from 'leaflet';
 
-import { MAP_CONTAINER_NEGATIVE_MARGIN, DC_CENTER } from '../constants';
+import { MAP_CONTAINER_NEGATIVE_MARGIN } from '../constants';
 
 export default function UsaMapContainer({
     negativeMargin = false,
@@ -41,7 +40,6 @@ export default function UsaMapContainer({
             }}
         >
             <MobileZoomer />
-            <PortalContainerSetter containerRef={containerRef} />
             {children}
         </MapContainer>
     );
@@ -66,22 +64,4 @@ function useMapZoom() {
             md: 4.5,
         }) ?? 4.5
     );
-}
-
-function PortalContainerSetter({
-    containerRef,
-}: {
-    containerRef?: React.MutableRefObject<Element | undefined>;
-}) {
-    const map = useMap();
-    if (containerRef && !containerRef.current) {
-        // Create container div for spending bucket animation
-        const popupContainer = document.createElement('div');
-        L.popup({ className: 'portal-container', closeButton: false })
-            .setLatLng(DC_CENTER)
-            .setContent(popupContainer)
-            .openOn(map);
-        containerRef.current = popupContainer;
-    }
-    return null;
 }

--- a/src/app/src/index.css
+++ b/src/app/src/index.css
@@ -25,3 +25,23 @@ ul {
 .leaflet-arcPathsPane-pane {
     z-index: 800;
 }
+
+.portal-container {
+    margin-bottom: 0;
+    left: -25px !important;
+}
+
+.portal-container .leaflet-popup-content-wrapper {
+    background: none;
+    color: none;
+    box-shadow: none;
+}
+
+.portal-container .leaflet-popup-content {
+    width: fit-content !important;
+    margin: 0;
+}
+
+.portal-container > .leaflet-popup-tip-container {
+    display: none;
+}


### PR DESCRIPTION
## Overview

Builds off of the work of #75 * and positions the animated spending bucket to be fixed over DC. In order for dynamic content to continue to re-render from within a leaflet UI layer as the time value (and associated spending values) updates, we take advantage of [createPortals](https://react.dev/reference/react-dom/createPortal), used elsewhere in the project for tooltip rendering.

Closes #76 
Co-authored by @mstone121 

~~*Since this is still a work in progress it's assumed there may be some changes to this branch on rebase~~
### Demo

![Screenshot 2023-03-21 at 10 34 00 AM](https://user-images.githubusercontent.com/36374797/226639468-35812216-2c07-4603-99f9-5c003dcc21c8.png)

## Testing Instructions

- `scripts/server`
- Confirm bucket displays over animated map and updates accordingly after selecting "play" and "replay" buttons
- Confirm bucket remains positioned over DC at different window sizes

 ## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
