### PR TITLE
Update budget tracker style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ and this project adheres to
     [#69](https://github.com/azavea/green-equity-demo/pull/69)
 -   Make other category remainder of spending
     [#71](https://github.com/azavea/green-equity-demo/pull/71)
+-   Update budget tracker style
+    [#89](https://github.com/azavea/green-equity-demo/pull/89)
 
 ### Fixed
 

--- a/src/app/src/components/BudgetTracker.tsx
+++ b/src/app/src/components/BudgetTracker.tsx
@@ -29,16 +29,14 @@ export default function BudgetTracker() {
         [spending?.results]
     );
 
-    const date = new Date(lastUpdated.lastUpdated);
-
     return (
         <Box
             background='#F6F8FF'
             width='100%'
-            pt={10}
-            pb={10}
-            pl={25}
-            pr={25}
+            pt={5}
+            pb={5}
+            pl={15}
+            pr={15}
             zIndex={1}
         >
             <Stack
@@ -47,20 +45,18 @@ export default function BudgetTracker() {
                 maxWidth='800px'
                 margin='auto'
             >
-                <VStack
-                    alignItems={isMobileMode ? 'center' : 'flex-start'}
-                    pl={4}
-                    pb={5}
-                >
+                <VStack alignItems='flex-start' pl={4} pb={5}>
                     <Text fontSize={24} fontWeight={700}>
                         BIL budget tracker
                     </Text>
-                    <Text fontSize={20} fontWeight={500}>
-                        $550B available in bill
+                    <Text
+                        fontSize={20}
+                        fontWeight={500}
+                        style={{ marginTop: 0 }}
+                    >
+                        Amount awarded of $550B budget
                     </Text>
-                    <Text fontSize={14}>
-                        Updated {date.toLocaleDateString()}
-                    </Text>
+                    {spendingSum ? <MoneyLeft spending={spendingSum} /> : null}
                 </VStack>
                 {spendingSum ? (
                     <BudgetTrackerProgressBar spending={spendingSum} />
@@ -72,96 +68,76 @@ export default function BudgetTracker() {
     );
 }
 
-function BudgetTrackerProgressBar({ spending }: { spending: number }) {
-    const isMobileMode = useIsMobileMode();
+function MoneyLeft({ spending }: { spending: number }) {
+    const date = new Date(lastUpdated.lastUpdated);
+    const billionsLeft = (550 - spending / 1_000_000_000).toFixed();
+
     return (
-        <VStack
-            spacing={0}
-            flexGrow={1}
-            maxWidth={isMobileMode ? undefined : 'md'}
-        >
-            <BudgetTrackerProgressBarProgress spending={spending} />
-            <BudgetTrackerProgressBarTicks />
-            <BudgetTrackerProgressBarLabels />
-        </VStack>
+        <Text fontSize={20} style={{ marginTop: 0 }}>
+            ${billionsLeft}B left as of {date.toLocaleDateString()}
+        </Text>
     );
 }
 
 const progressWidth = '90%';
 const progressColor = '#465EB5';
 const spendingDenominator = 550_000_000_000 / 100;
-function BudgetTrackerProgressBarProgress({ spending }: { spending: number }) {
+function BudgetTrackerProgressBar({ spending }: { spending: number }) {
+    const isMobileMode = useIsMobileMode();
+
     const spendingPercent = spending / spendingDenominator;
     const moneyLeftPercent = 100 - spendingPercent;
     const spendingBillions = spending / 1_000_000_000;
 
     return (
-        <HStack
-            height={30}
-            width={progressWidth}
+        <VStack
             spacing={0}
-            border={`1px solid ${progressColor}`}
+            flexGrow={1}
+            justifyContent='center'
+            maxWidth={isMobileMode ? undefined : 'md'}
         >
-            <div
-                style={{
-                    background: progressColor,
-                    width: `${spendingPercent}%`,
-                    height: '100%',
-                    textAlign: 'center',
-                    color: 'white',
-                }}
+            <HStack
+                height={30}
+                width={progressWidth}
+                spacing={0}
+                border={`1px solid ${progressColor}`}
             >
-                {spendingBillions.toFixed()}B awarded
-            </div>
-            <div
-                style={{
-                    width: `${moneyLeftPercent}%`,
-                    height: '100%',
-                    textAlign: 'center',
-                }}
-            >
-                {(550 - spendingBillions).toFixed()}B left
-            </div>
-        </HStack>
-    );
-}
-
-const baseTickStyle = { height: '100%', width: '50%' };
-const fullTick = 'solid 1px grey';
-const halfTick = 'solid .5px grey';
-function BudgetTrackerProgressBarTicks() {
-    return (
-        <HStack height='12px' width={progressWidth} spacing={0}>
-            <div
-                style={{
-                    ...baseTickStyle,
-                    borderLeft: fullTick,
-                    borderRight: halfTick,
-                }}
-            />
-            <div
-                style={{
-                    ...baseTickStyle,
-                    borderRight: fullTick,
-                    borderLeft: halfTick,
-                }}
-            />
-        </HStack>
-    );
-}
-
-function BudgetTrackerProgressBarLabels() {
-    return (
-        <HStack
-            height='12px'
-            width='100%'
-            justifyContent='space-between'
-            pt={5}
-            pl={4} // There could be a better way to align the labels
-        >
-            <Text>0%</Text>
-            <Text>50%</Text>
-            <Text>100%</Text>
-        </HStack>
+                <div
+                    style={{
+                        background: progressColor,
+                        width: `${spendingPercent}%`,
+                        height: '100%',
+                        textAlign: 'center',
+                        color: 'white',
+                    }}
+                >
+                    ${spendingBillions.toFixed()}B
+                </div>
+                <div
+                    style={{
+                        width: `${moneyLeftPercent}%`,
+                        height: '100%',
+                        textAlign: 'center',
+                    }}
+                />
+            </HStack>
+            <Box paddingTop={2} width={progressWidth}>
+                <Box
+                    marginLeft={`calc(${spendingPercent}% - 7px)`}
+                    width={0}
+                    height={0}
+                    borderLeft='7px solid transparent'
+                    borderRight='7px solid transparent'
+                    borderBottom='10px solid black'
+                />
+                <Text
+                    marginLeft={`${spendingPercent}%`}
+                    position='relative'
+                    transform='translateX(-50%)'
+                >
+                    {spendingPercent.toFixed()}%
+                </Text>
+            </Box>
+        </VStack>
     );
 }


### PR DESCRIPTION
## Overview

This PR updates the budget tracker style.

Closes #68 

### Demo

Wide
<img width="916" alt="Screenshot 2023-03-23 at 3 03 58 PM" src="https://user-images.githubusercontent.com/8356789/227339136-d7ea92e4-87de-45fc-ad8e-d2b42c7e73a7.png">

Mobile
<img width="594" alt="Screenshot 2023-03-23 at 3 04 04 PM" src="https://user-images.githubusercontent.com/8356789/227339142-660a6bf9-1d69-4c5f-a621-4190122566f5.png">

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

- http://localhost:8765/
  - [ ] Ensure the budget tracker looks like the designs

 ## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
