### PR TITLE
Adjust animated map to report per capita amounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ and this project adheres to
     [#71](https://github.com/azavea/green-equity-demo/pull/71)
 -   Update budget tracker style
     [#89](https://github.com/azavea/green-equity-demo/pull/89)
+-   Change animated map to use per-capita data
+    [#96](https://github.com/azavea/green-equity-demo/pull/96)
 
 ### Fixed
 

--- a/src/app/dataScripts/fetchData.ts
+++ b/src/app/dataScripts/fetchData.ts
@@ -12,13 +12,14 @@ async function fetchData() {
         await mkdir(dataDir);
     }
 
-    // fetchSpendingOverTimeData relies on json product of fetchStatesData
-    await fetchStatesData();
-
+    // fetchSpendingOverTimeData relies on json products
+    // of fetchStatesData and fetchPerCapitaSpendingData
     const [perCapitaResult] = await Promise.allSettled([
+        fetchStatesData(),
         fetchPerCapitaSpendingData(),
-        fetchSpendingOverTimeData(),
     ]);
+
+    await fetchSpendingOverTimeData();
 
     if (perCapitaResult.status === 'fulfilled') {
         const today = new Date();

--- a/src/app/dataScripts/nodeConstants.ts
+++ b/src/app/dataScripts/nodeConstants.ts
@@ -1,5 +1,7 @@
 import path from 'node:path';
 
+import { Category } from '../src/enums';
+
 export const dataDir = path.join(__dirname, '..', 'src', 'data');
 
 export const statesJSON = path.join(
@@ -8,4 +10,12 @@ export const statesJSON = path.join(
     'src',
     'data',
     'states.json'
+);
+
+export const perCapitaJSON = path.join(
+    __dirname,
+    '..',
+    'src',
+    'data',
+    `${Category.ALL}.spending.json`
 );

--- a/src/app/src/components/AnimatedArcsAndMap/AnimatedArcsAndMap.tsx
+++ b/src/app/src/components/AnimatedArcsAndMap/AnimatedArcsAndMap.tsx
@@ -9,13 +9,14 @@ import {
     Progress,
     Tag,
     TagLabel,
+    VStack,
 } from '@chakra-ui/react';
 
 import UsaMapContainer from '../UsaMapContainer';
+import PerCapitaMapLegend from '../PerCapitaMap/PerCapitaMapLegend';
 import TimeControlIcon from './TimeControlIcon';
 
 import AnimatedMap from './AnimatedMap';
-import AnimatedMapLegend from './AnimatedMapLegend';
 import { useGetSpendingOverTimeQuery } from '../../api';
 import { getSpendingByStateAtTime, PROGRESS_FINAL_STEP } from '../../util';
 import { MONTHLY_TIME_DURATION } from '../../constants';
@@ -73,9 +74,8 @@ export default function AnimatedArcsAndMap() {
             </Heading>
             <Spacer></Spacer>
             {data && spendingAtTimeByState && !isFetching ? (
-                <>
-                    <AnimatedMapLegend />
-                    <UsaMapContainer>
+                <VStack width='100%' justifyContent='center'>
+                    <UsaMapContainer negativeMargin>
                         <AnimatedTotalSpendingBucket
                             spendingAtTimeByState={spendingAtTimeByState}
                         />
@@ -84,6 +84,7 @@ export default function AnimatedArcsAndMap() {
                             spendingAtTimeByState={spendingAtTimeByState}
                         />
                     </UsaMapContainer>
+                    <PerCapitaMapLegend />
                     <Box width='100%' textAlign={'center'}>
                         <IconButton
                             aria-label='Play time progress animation'
@@ -118,7 +119,7 @@ export default function AnimatedArcsAndMap() {
                             </TagLabel>
                         </Tag>
                     </Box>
-                </>
+                </VStack>
             ) : (
                 <Center p={4}>
                     <CircularProgress isIndeterminate />

--- a/src/app/src/components/AnimatedArcsAndMap/AnimatedMap.tsx
+++ b/src/app/src/components/AnimatedArcsAndMap/AnimatedMap.tsx
@@ -40,7 +40,7 @@ export default function AnimatedMap({
                                         StateProperties
                                     >
                                 ).properties.STUSPS
-                            ]?.aggregated_amount
+                            ]?.per_capita
                         ),
                     });
             });
@@ -70,7 +70,7 @@ export default function AnimatedMap({
             layer.on('add', createArcPath);
             const defaultFillColor = getColor(
                 spendingAtTimeByState[feature.properties.STUSPS.toString()]
-                    ?.aggregated_amount
+                    ?.per_capita
             );
             layer &&
                 layer.setStyle({

--- a/src/app/src/components/AnimatedArcsAndMap/AnimatedMap.tsx
+++ b/src/app/src/components/AnimatedArcsAndMap/AnimatedMap.tsx
@@ -8,8 +8,8 @@ import StatesLayer from '../StatesLayer';
 
 import { SpendingByGeographyAtMonth } from '../../types/api';
 import { StateFeature } from '../../types/states';
+import { getAmountCategory } from '../../util';
 
-import { TOTAL_BIL_AMOUNT } from '../../constants';
 import useCreateArcPath from './useCreateArcPath';
 
 export default function AnimatedMap({
@@ -87,10 +87,5 @@ export default function AnimatedMap({
 }
 
 function getColor(amount: number | undefined): string {
-    const fractionOfTotalAwards = amount ? amount / TOTAL_BIL_AMOUNT : 0;
-    return fractionOfTotalAwards > 0.1
-        ? '#465EB5'
-        : fractionOfTotalAwards > 0.05
-        ? '#94A4DF'
-        : 'white';
+    return getAmountCategory(amount ?? -1).color;
 }

--- a/src/app/src/components/AnimatedArcsAndMap/AnimatedTotalSpendingBucket.tsx
+++ b/src/app/src/components/AnimatedArcsAndMap/AnimatedTotalSpendingBucket.tsx
@@ -36,7 +36,7 @@ export default function AnimatedTotalSpendingBucket({
             const totalAwardsAtTime: number = Object.values(
                 spendingAtTimeByState
             ).reduce((sum, stateResults) => {
-                sum += stateResults && stateResults.aggregated_amount;
+                sum += stateResults && stateResults.per_capita;
                 return sum;
             }, 0);
             totalAwardsAtTime && setTotalSpendingAtTime(totalAwardsAtTime);

--- a/src/app/src/components/AnimatedArcsAndMap/useCreateArcPath.tsx
+++ b/src/app/src/components/AnimatedArcsAndMap/useCreateArcPath.tsx
@@ -66,7 +66,7 @@ function getPathAnimationValues({
 }) {
     const totalTime = totalTimeSteps * MONTHLY_TIME_DURATION;
     const firstAward = spendingForState.results.find(
-        data => data.aggregated_amount > 0
+        data => data.per_capita > 0
     );
     if (!firstAward) {
         return {

--- a/src/app/src/types/api.d.ts
+++ b/src/app/src/types/api.d.ts
@@ -65,7 +65,7 @@ export type SpendingOverTimeByStateRequest = {
 };
 
 export type MonthlySpendingOverTime = {
-    aggregated_amount: number;
+    per_capita: number;
     time_period: {
         fiscal_year: number;
         month: number;
@@ -91,7 +91,7 @@ export type MonthlySpendingOverTimeByState = {
 
 export type SpendingByGeographyAtMonth = {
     [k: string]: {
-        aggregated_amount: number;
+        per_capita: number;
         time_period: {
             fiscal_year: number;
             month: number;

--- a/src/app/src/util.ts
+++ b/src/app/src/util.ts
@@ -224,21 +224,24 @@ export function abbreviateNumber(amount: number): string {
 }
 
 const START_YEAR = 2021;
+const FISCAL_YEAR_MONTH_OFFSET = 3; // FY 2024 begins 10/1/23
 const END_DATE = new Date();
 export const PROGRESS_FINAL_STEP = (() => {
-    const final_month_step = END_DATE.getMonth();
-    const final_year_step = END_DATE.getFullYear();
-    return 12 * (final_year_step - START_YEAR) + final_month_step;
+    let finalFiscalMonth = END_DATE.getMonth() + FISCAL_YEAR_MONTH_OFFSET;
+    let finalFiscalYear = END_DATE.getFullYear();
+    if (finalFiscalMonth > 11) {
+        finalFiscalMonth = finalFiscalMonth % 12;
+        finalFiscalYear += 1;
+    }
+    return 12 * (finalFiscalYear - START_YEAR) + finalFiscalMonth;
 })();
 
 export function getSpendingByStateAtTime(
     timeValue: number,
     spending: MonthlySpendingOverTimeByState
 ): SpendingByGeographyAtMonth {
-    const isDecember = timeValue % 12 === 0;
-    const fiscalYearSelection =
-        2021 + Math.floor(isDecember ? timeValue / 13 : timeValue / 12);
-    const monthSelection = !!timeValue && isDecember ? 12 : timeValue % 12;
+    const fiscalYearSelection = START_YEAR + Math.floor(timeValue / 12);
+    const monthSelection = (timeValue % 12) + 1; // 1-indexed
     const spendingAtTimeValue = spending.map(stateSpending => {
         const resultAtTimeValue = stateSpending.results.find(entry => {
             return (


### PR DESCRIPTION
## Overview
Adjust the animated map to report per capita amounts.

Closes #80

### Demo

https://user-images.githubusercontent.com/38668450/230475312-d78a9734-7c03-4bcb-b86f-62548c566a65.mov

## Testing Instructions

- Delete entries from src/data (except the git-tracked geojsons)
- scripts/fetch-data
- scripts/server
 
 ## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
