### PR TITLE
Optimize arc animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,5 +75,6 @@ and this project adheres to
     [#84](https://github.com/azavea/green-equity-demo/pull/84)
 -   Reposition animated spending bucket over DC
     [#85](https://github.com/azavea/green-equity-demo/pull/85)
+-   Optimize arc animation [#97](https://github.com/azavea/green-equity-demo/pull/97)
 
 ### Removed


### PR DESCRIPTION
## Overview
The arc animation was getting sluggish. Add `useCallback()` to reduce the amount of times arcs are rendered to the map.

Closes #91

### Demo
With this debug statement added, I observe the following A/B:

```diff
diff --git a/src/app/src/components/AnimatedArcsAndMap/AnimatedMap.tsx b/src/app/src/components/AnimatedArcsAndMap/AnimatedMap.tsx
index 399fb92..95f23ea 100644
--- a/src/app/src/components/AnimatedArcsAndMap/AnimatedMap.tsx
+++ b/src/app/src/components/AnimatedArcsAndMap/AnimatedMap.tsx
@@ -69,6 +69,7 @@ export default function AnimatedMap({
                     layer: L.GeoJSON<StateProperties, StateGeometry>
                 ) => {
                     layer.on('add', createArcPath);
+                    layer.on('add', () => console.log('adding layer'));
                     const defaultFillColor = getColor(
                         spendingAtTimeByState[
```
**Before**
15,198 calls

<img width="1179" alt="Screenshot 2023-04-06 at 4 57 11 PM" src="https://user-images.githubusercontent.com/38668450/230493316-a08e4241-7bd1-41eb-8474-e653aa2e6423.png">



**After**
1,428 calls
(51 calls per interval, give or take, I take it?--some of these might be rolled up with the initial render before animation, and React.StrictMode does extra harmless rendering also, but this seems like the right order of magnitude)

<img width="1201" alt="Screenshot 2023-04-06 at 4 57 55 PM" src="https://user-images.githubusercontent.com/38668450/230493336-7629dcd4-da1e-4ee9-babe-1060919a8603.png">


## Testing Instructions

- Play the animated map!

 ## Checklist

- [x] `fixup!` commits have been squashed
- [ ] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [ ] CI passes after rebase
