### PR TITLE
Add disadvantaged communities choropleth map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to
     [#77](https://github.com/azavea/green-equity-demo/pull/77)
 -   Lazy load high-res state boundaries
     [#82](https://github.com/azavea/green-equity-demo/pull/82)
+-   Add disadvantaged communities choropleth map
+    [#100](https://github.com/azavea/green-equity-demo/pull/100)
 
 ### Changed
 

--- a/src/app/src/App.tsx
+++ b/src/app/src/App.tsx
@@ -1,5 +1,7 @@
+import { ReactNode, useState } from 'react';
 import {
     Button,
+    ButtonGroup,
     Center,
     Heading,
     Spacer,
@@ -15,7 +17,14 @@ import SimpleModal from './components/SimpleModal';
 import BudgetTracker from './components/BudgetTracker';
 import Attribution from './components/Attribution';
 
+enum TopMap {
+    PER_CAPITA,
+    EQUITY,
+}
+
 function App() {
+    const [topMap, setTopMap] = useState<TopMap>(TopMap.PER_CAPITA);
+
     return (
         <Center style={{ textAlign: 'center' }}>
             <VStack mt={4} spacing={4} width='100%'>
@@ -33,7 +42,10 @@ function App() {
                 <Spacer />
                 <BudgetTracker />
                 <Spacer />
-                <PerCapitaMap />
+                <TopMapTabSelector value={topMap} onChange={setTopMap} />
+                {topMap === TopMap.PER_CAPITA ? (
+                    <PerCapitaMap />
+                ) : topMap === TopMap.EQUITY ? null : null}
                 <div style={{ height: 100 }} />
                 <AnimatedArcsAndMap />
                 <div style={{ height: 36 }} />
@@ -44,6 +56,40 @@ function App() {
                 <footer>©2023 Element 84</footer>
             </VStack>
         </Center>
+    );
+}
+
+function TopMapTabSelector({
+    value,
+    onChange,
+}: {
+    value: TopMap;
+    onChange: (value: TopMap) => void;
+}) {
+    const TopMapTabButton = ({
+        topMap,
+        children,
+    }: {
+        topMap: TopMap;
+        children: ReactNode;
+    }) => (
+        <Button
+            variant={value === topMap ? 'solid' : 'ghost'}
+            onClick={() => onChange(topMap)}
+        >
+            {children}
+        </Button>
+    );
+
+    return (
+        <ButtonGroup zIndex={1} pb={10}>
+            <TopMapTabButton topMap={TopMap.PER_CAPITA}>
+                Funding per capita
+            </TopMapTabButton>
+            <TopMapTabButton topMap={TopMap.EQUITY}>
+                Disadvantaged communities
+            </TopMapTabButton>
+        </ButtonGroup>
     );
 }
 

--- a/src/app/src/App.tsx
+++ b/src/app/src/App.tsx
@@ -11,6 +11,7 @@ import {
 } from '@chakra-ui/react';
 
 import PerCapitaMap from './components/PerCapitaMap';
+import { EquityMap } from './components/EquityMap';
 import AnimatedArcsAndMap from './components/AnimatedArcsAndMap';
 import DataSandbox from './components/DataSandbox';
 import SimpleModal from './components/SimpleModal';
@@ -45,7 +46,9 @@ function App() {
                 <TopMapTabSelector value={topMap} onChange={setTopMap} />
                 {topMap === TopMap.PER_CAPITA ? (
                     <PerCapitaMap />
-                ) : topMap === TopMap.EQUITY ? null : null}
+                ) : topMap === TopMap.EQUITY ? (
+                    <EquityMap />
+                ) : null}
                 <div style={{ height: 100 }} />
                 <AnimatedArcsAndMap />
                 <div style={{ height: 36 }} />

--- a/src/app/src/components/AnimatedArcsAndMap/AnimatedArcsAndMap.tsx
+++ b/src/app/src/components/AnimatedArcsAndMap/AnimatedArcsAndMap.tsx
@@ -13,13 +13,13 @@ import {
 } from '@chakra-ui/react';
 
 import UsaMapContainer from '../UsaMapContainer';
-import PerCapitaMapLegend from '../PerCapitaMap/PerCapitaMapLegend';
+import MapLegend from '../MapLegend';
 import TimeControlIcon from './TimeControlIcon';
 
 import AnimatedMap from './AnimatedMap';
 import { useGetSpendingOverTimeQuery } from '../../api';
 import { getSpendingByStateAtTime, PROGRESS_FINAL_STEP } from '../../util';
-import { MONTHLY_TIME_DURATION } from '../../constants';
+import { AMOUNT_CATEGORIES, MONTHLY_TIME_DURATION } from '../../constants';
 import AnimatedTotalSpendingBucket from './AnimatedTotalSpendingBucket';
 
 export default function AnimatedArcsAndMap() {
@@ -84,7 +84,11 @@ export default function AnimatedArcsAndMap() {
                             spendingAtTimeByState={spendingAtTimeByState}
                         />
                     </UsaMapContainer>
-                    <PerCapitaMapLegend />
+                    <MapLegend
+                        categories={AMOUNT_CATEGORIES}
+                        label='Dollars per capita'
+                        monetary
+                    />
                     <Box width='100%' textAlign={'center'}>
                         <IconButton
                             aria-label='Play time progress animation'

--- a/src/app/src/components/Attribution.tsx
+++ b/src/app/src/components/Attribution.tsx
@@ -62,6 +62,14 @@ export default function Attribution() {
                             category={category}
                         />
                     ))}
+                <Text fontSize={12} pt={1}>
+                    The proportions of state populations living in disadvantaged
+                    communities were taken from the{' '}
+                    <Link href='https://screeningtool.geoplatform.gov/en/downloads#3/33.47/-97.5'>
+                        Climate and Economic Justice Screening Tool
+                    </Link>
+                    , which is based on 2010 Census data.
+                </Text>
             </details>
             <Text fontSize={12} pt={4}>
                 The maps on this page were created with{' '}

--- a/src/app/src/components/EquityMap/EquityMap.tsx
+++ b/src/app/src/components/EquityMap/EquityMap.tsx
@@ -1,0 +1,59 @@
+import { useCallback } from 'react';
+import StatesLayer from '../StatesLayer';
+import {
+    StateFeature,
+    StatesLayer as StatesLayerType,
+} from '../../types/states';
+
+import MapLegend from '../MapLegend';
+import UsaMapContainer from '../UsaMapContainer';
+import * as disadvantagedTractsJson from '../../data/disadvantagedTracts.json';
+import { QUARTILE_CATEGORIES, STATE_STYLE_BASE } from '../../constants';
+import { getAmountCategory } from '../../util';
+
+const disadvantagedTracts = Array.from(disadvantagedTractsJson);
+
+export function EquityMap() {
+    const onEachFeature = useCallback(
+        (feature: StateFeature, layer: StatesLayerType) => {
+            const disadvantagedPopulationSums = disadvantagedTracts.find(
+                datum => datum['State'] === feature.properties.NAME
+            );
+            if (disadvantagedPopulationSums === undefined) {
+                return;
+            }
+            const proportionDisadvantaged =
+                Number.parseInt(disadvantagedPopulationSums.Disadvantaged) /
+                Number.parseInt(disadvantagedPopulationSums.Total);
+            layer.setStyle({
+                fillColor: getAmountCategory(
+                    proportionDisadvantaged,
+                    QUARTILE_CATEGORIES
+                ).color,
+            });
+            layer.on('mouseover', () => {
+                layer.setStyle({ weight: 2 });
+            });
+            layer.on('mouseout', () => {
+                layer.setStyle({
+                    weight: STATE_STYLE_BASE.weight,
+                });
+            });
+        },
+        []
+    );
+
+    return (
+        <>
+            <div style={{ height: 125 }} />
+            <UsaMapContainer negativeMargin>
+                <StatesLayer onEachFeature={onEachFeature} />
+            </UsaMapContainer>
+            <MapLegend
+                categories={QUARTILE_CATEGORIES}
+                label='Population in disadvantaged communities'
+                monetary={false}
+            />
+        </>
+    );
+}

--- a/src/app/src/components/EquityMap/index.tsx
+++ b/src/app/src/components/EquityMap/index.tsx
@@ -1,0 +1,1 @@
+export { EquityMap } from './EquityMap';

--- a/src/app/src/components/MapLegend.tsx
+++ b/src/app/src/components/MapLegend.tsx
@@ -1,9 +1,38 @@
 import { Box, Text, HStack, VStack } from '@chakra-ui/react';
-import { AMOUNT_CATEGORIES } from '../../constants';
-import useIsMobileMode from '../../useIsMobileMode';
+import { AmountCategory } from '../types';
+import useIsMobileMode from '../useIsMobileMode';
 
-export default function PerCapitaMapLegend() {
+export default function MapLegend({
+    categories,
+    label,
+    monetary,
+}: {
+    categories: AmountCategory[];
+    label: string;
+    monetary: boolean;
+}) {
     const isMobileMode = useIsMobileMode();
+
+    const monetaryLabel = (
+        category: AmountCategory,
+        nextCategory: AmountCategory | undefined
+    ) => {
+        if (nextCategory) {
+            return `$${category.min.toLocaleString()}-$${(
+                nextCategory.min - 1
+            ).toLocaleString()}`;
+        }
+        return `$${category.min.toLocaleString()}+`;
+    };
+
+    const percentLabel = (
+        category: AmountCategory,
+        _nextCategory: AmountCategory | undefined
+    ) => {
+        return `${category.min * 100}%`;
+    };
+
+    const getLabel = monetary ? monetaryLabel : percentLabel;
 
     return (
         <VStack
@@ -14,18 +43,13 @@ export default function PerCapitaMapLegend() {
             minWidth={isMobileMode ? '100%' : '520px'}
         >
             <Text alignSelf='flex-start' fontSize={24}>
-                Dollars per capita
+                {label}
             </Text>
             <HStack width='100%' spacing={0.5}>
-                {[...AMOUNT_CATEGORIES]
+                {[...categories]
                     .reverse()
                     .map((category, index, categories) => {
                         const nextCategory = categories[index + 1];
-                        const label = nextCategory
-                            ? `$${category.min.toLocaleString()}-$${(
-                                  nextCategory.min - 1
-                              ).toLocaleString()}`
-                            : `$${category.min.toLocaleString()}+`;
 
                         return (
                             <VStack flex={1} key={category.min}>
@@ -38,7 +62,7 @@ export default function PerCapitaMapLegend() {
                                     fontSize={isMobileMode ? 12 : 14}
                                     alignSelf='flex-start'
                                 >
-                                    {label}
+                                    {getLabel(category, nextCategory)}
                                 </Text>
                             </VStack>
                         );

--- a/src/app/src/components/PerCapitaMap/PerCapitaMap.tsx
+++ b/src/app/src/components/PerCapitaMap/PerCapitaMap.tsx
@@ -7,7 +7,7 @@ import UsaMapContainer from '../UsaMapContainer';
 import StatesLayer from '../StatesLayer';
 import SpendingTooltip from './SpendingTooltip';
 import SpendingCategorySelector from './SpendingCategorySelector';
-import PerCapitaMapLegend from './PerCapitaMapLegend';
+import MapLegend from '../MapLegend';
 
 import { Category, isCategory } from '../../enums';
 import useSpendingByCategoryByState from './useSpendingByCategoryByState';
@@ -16,7 +16,7 @@ import {
     StatesLayer as StatesLayerType,
 } from '../../types/states';
 import { getAmountCategory } from '../../util';
-import { STATE_STYLE_BASE } from '../../constants';
+import { AMOUNT_CATEGORIES, STATE_STYLE_BASE } from '../../constants';
 import { StateSpending } from '../../types/api';
 
 export default function PerCapitaMap() {
@@ -41,7 +41,11 @@ export default function PerCapitaMap() {
                     </Center>
                 )}
             </UsaMapContainer>
-            <PerCapitaMapLegend />
+            <MapLegend
+                categories={AMOUNT_CATEGORIES}
+                label='Dollars per capita'
+                monetary
+            />
         </VStack>
     );
 }

--- a/src/app/src/constants.ts
+++ b/src/app/src/constants.ts
@@ -10,6 +10,13 @@ export const AMOUNT_CATEGORIES: AmountCategory[] = [
     { min: 0, color: theme.colors.green[100] },
 ];
 
+export const QUARTILE_CATEGORIES: AmountCategory[] = [
+    { min: 0.75, color: theme.colors.green[900] },
+    { min: 0.5, color: theme.colors.green[600] },
+    { min: 0.25, color: theme.colors.green[300] },
+    { min: 0, color: theme.colors.green[100] },
+];
+
 export const STATE_STYLE_BASE = Object.freeze({
     color: 'black',
     weight: 0.62,

--- a/src/app/src/data/disadvantagedTracts.json
+++ b/src/app/src/data/disadvantagedTracts.json
@@ -1,0 +1,338 @@
+[
+    {
+        "State": "Alabama",
+        "NotDisadvantaged": "2647237.0",
+        "Disadvantaged": "2229013.0",
+        "Total": "4876250.0"
+    },
+    {
+        "State": "Alaska",
+        "NotDisadvantaged": "598054.0",
+        "Disadvantaged": "130764.0",
+        "Total": "728818.0"
+    },
+    {
+        "State": "American Samoa",
+        "NotDisadvantaged": "17.0",
+        "Disadvantaged": "55502.0",
+        "Total": "55519.0"
+    },
+    {
+        "State": "Arizona",
+        "NotDisadvantaged": "4529277.0",
+        "Disadvantaged": "2488146.0",
+        "Total": "7017423.0"
+    },
+    {
+        "State": "Arkansas",
+        "NotDisadvantaged": "1358917.0",
+        "Disadvantaged": "1640453.0",
+        "Total": "2999370.0"
+    },
+    {
+        "State": "California",
+        "NotDisadvantaged": "24395849.0",
+        "Disadvantaged": "14882581.0",
+        "Total": "39278430.0"
+    },
+    {
+        "State": "Colorado",
+        "NotDisadvantaged": "4549428.0",
+        "Disadvantaged": "1060921.0",
+        "Total": "5610349.0"
+    },
+    {
+        "State": "Connecticut",
+        "NotDisadvantaged": "2868717.0",
+        "Disadvantaged": "706357.0",
+        "Total": "3575074.0"
+    },
+    {
+        "State": "Delaware",
+        "NotDisadvantaged": "831700.0",
+        "Disadvantaged": "125548.0",
+        "Total": "957248.0"
+    },
+    {
+        "State": "District of Columbia",
+        "NotDisadvantaged": "462890.0",
+        "Disadvantaged": "229793.0",
+        "Total": "692683.0"
+    },
+    {
+        "State": "Florida",
+        "NotDisadvantaged": "12609645.0",
+        "Disadvantaged": "8291991.0",
+        "Total": "20901636.0"
+    },
+    {
+        "State": "Georgia",
+        "NotDisadvantaged": "6838391.0",
+        "Disadvantaged": "3565456.0",
+        "Total": "10403847.0"
+    },
+    {
+        "State": "Guam",
+        "NotDisadvantaged": "144202.0",
+        "Disadvantaged": "15156.0",
+        "Total": "159358.0"
+    },
+    {
+        "State": "Hawaii",
+        "NotDisadvantaged": "1212526.0",
+        "Disadvantaged": "209568.0",
+        "Total": "1422094.0"
+    },
+    {
+        "State": "Idaho",
+        "NotDisadvantaged": "1157929.0",
+        "Disadvantaged": "559821.0",
+        "Total": "1717750.0"
+    },
+    {
+        "State": "Illinois",
+        "NotDisadvantaged": "9084121.0",
+        "Disadvantaged": "3686510.0",
+        "Total": "12770631.0"
+    },
+    {
+        "State": "Indiana",
+        "NotDisadvantaged": "4748610.0",
+        "Disadvantaged": "1917093.0",
+        "Total": "6665703.0"
+    },
+    {
+        "State": "Iowa",
+        "NotDisadvantaged": "2601987.0",
+        "Disadvantaged": "537521.0",
+        "Total": "3139508.0"
+    },
+    {
+        "State": "Kansas",
+        "NotDisadvantaged": "2172569.0",
+        "Disadvantaged": "738083.0",
+        "Total": "2910652.0"
+    },
+    {
+        "State": "Kentucky",
+        "NotDisadvantaged": "2462975.0",
+        "Disadvantaged": "1986077.0",
+        "Total": "4449052.0"
+    },
+    {
+        "State": "Louisiana",
+        "NotDisadvantaged": "2380507.0",
+        "Disadvantaged": "2283855.0",
+        "Total": "4664362.0"
+    },
+    {
+        "State": "Maine",
+        "NotDisadvantaged": "953963.0",
+        "Disadvantaged": "381529.0",
+        "Total": "1335492.0"
+    },
+    {
+        "State": "Maryland",
+        "NotDisadvantaged": "5088706.0",
+        "Disadvantaged": "930142.0",
+        "Total": "6018848.0"
+    },
+    {
+        "State": "Massachusetts",
+        "NotDisadvantaged": "5459598.0",
+        "Disadvantaged": "1390955.0",
+        "Total": "6850553.0"
+    },
+    {
+        "State": "Michigan",
+        "NotDisadvantaged": "6951041.0",
+        "Disadvantaged": "3014224.0",
+        "Total": "9965265.0"
+    },
+    {
+        "State": "Minnesota",
+        "NotDisadvantaged": "4846721.0",
+        "Disadvantaged": "716657.0",
+        "Total": "5563378.0"
+    },
+    {
+        "State": "Mississippi",
+        "NotDisadvantaged": "1213887.0",
+        "Disadvantaged": "1770531.0",
+        "Total": "2984418.0"
+    },
+    {
+        "State": "Missouri",
+        "NotDisadvantaged": "4029401.0",
+        "Disadvantaged": "2075509.0",
+        "Total": "6104910.0"
+    },
+    {
+        "State": "Montana",
+        "NotDisadvantaged": "727594.0",
+        "Disadvantaged": "323055.0",
+        "Total": "1050649.0"
+    },
+    {
+        "State": "Nebraska",
+        "NotDisadvantaged": "1487546.0",
+        "Disadvantaged": "427025.0",
+        "Total": "1914571.0"
+    },
+    {
+        "State": "Nevada",
+        "NotDisadvantaged": "1940950.0",
+        "Disadvantaged": "1031432.0",
+        "Total": "2972382.0"
+    },
+    {
+        "State": "New Hampshire",
+        "NotDisadvantaged": "1257653.0",
+        "Disadvantaged": "90471.0",
+        "Total": "1348124.0"
+    },
+    {
+        "State": "New Jersey",
+        "NotDisadvantaged": "6671554.0",
+        "Disadvantaged": "2206949.0",
+        "Total": "8878503.0"
+    },
+    {
+        "State": "New Mexico",
+        "NotDisadvantaged": "1007100.0",
+        "Disadvantaged": "1085354.0",
+        "Total": "2092454.0"
+    },
+    {
+        "State": "New York",
+        "NotDisadvantaged": "12710588.0",
+        "Disadvantaged": "6805010.0",
+        "Total": "19515598.0"
+    },
+    {
+        "State": "North Carolina",
+        "NotDisadvantaged": "6465696.0",
+        "Disadvantaged": "3799180.0",
+        "Total": "10264876.0"
+    },
+    {
+        "State": "North Dakota",
+        "NotDisadvantaged": "691437.0",
+        "Disadvantaged": "65280.0",
+        "Total": "756717.0"
+    },
+    {
+        "State": "Northern Mariana Islands",
+        "NotDisadvantaged": "2117.0",
+        "Disadvantaged": "51766.0",
+        "Total": "53883.0"
+    },
+    {
+        "State": "Ohio",
+        "NotDisadvantaged": "8319674.0",
+        "Disadvantaged": "3335723.0",
+        "Total": "11655397.0"
+    },
+    {
+        "State": "Oklahoma",
+        "NotDisadvantaged": "1103596.0",
+        "Disadvantaged": "2829274.0",
+        "Total": "3932870.0"
+    },
+    {
+        "State": "Oregon",
+        "NotDisadvantaged": "2998793.0",
+        "Disadvantaged": "1131010.0",
+        "Total": "4129803.0"
+    },
+    {
+        "State": "Pennsylvania",
+        "NotDisadvantaged": "9730810.0",
+        "Disadvantaged": "3060720.0",
+        "Total": "12791530.0"
+    },
+    {
+        "State": "Puerto Rico",
+        "NotDisadvantaged": "258424.0",
+        "Disadvantaged": "3060023.0",
+        "Total": "3318447.0"
+    },
+    {
+        "State": "Rhode Island",
+        "NotDisadvantaged": "791968.0",
+        "Disadvantaged": "265263.0",
+        "Total": "1057231.0"
+    },
+    {
+        "State": "South Carolina",
+        "NotDisadvantaged": "3014450.0",
+        "Disadvantaged": "2006356.0",
+        "Total": "5020806.0"
+    },
+    {
+        "State": "South Dakota",
+        "NotDisadvantaged": "622342.0",
+        "Disadvantaged": "233961.0",
+        "Total": "856303.0"
+    },
+    {
+        "State": "Tennessee",
+        "NotDisadvantaged": "3989061.0",
+        "Disadvantaged": "2720295.0",
+        "Total": "6709356.0"
+    },
+    {
+        "State": "Texas",
+        "NotDisadvantaged": "16989087.0",
+        "Disadvantaged": "11271769.0",
+        "Total": "28260856.0"
+    },
+    {
+        "State": "Utah",
+        "NotDisadvantaged": "2663195.0",
+        "Disadvantaged": "433653.0",
+        "Total": "3096848.0"
+    },
+    {
+        "State": "Vermont",
+        "NotDisadvantaged": "536506.0",
+        "Disadvantaged": "87807.0",
+        "Total": "624313.0"
+    },
+    {
+        "State": "Virgin Islands",
+        "NotDisadvantaged": "81881.0",
+        "Disadvantaged": "24524.0",
+        "Total": "106405.0"
+    },
+    {
+        "State": "Virginia",
+        "NotDisadvantaged": "6697759.0",
+        "Disadvantaged": "1750255.0",
+        "Total": "8448014.0"
+    },
+    {
+        "State": "Washington",
+        "NotDisadvantaged": "5974573.0",
+        "Disadvantaged": "1429534.0",
+        "Total": "7404107.0"
+    },
+    {
+        "State": "West Virginia",
+        "NotDisadvantaged": "793621.0",
+        "Disadvantaged": "1023684.0",
+        "Total": "1817305.0"
+    },
+    {
+        "State": "Wisconsin",
+        "NotDisadvantaged": "4850468.0",
+        "Disadvantaged": "940248.0",
+        "Total": "5790716.0"
+    },
+    {
+        "State": "Wyoming",
+        "NotDisadvantaged": "500735.0",
+        "Disadvantaged": "80289.0",
+        "Total": "581024.0"
+    }
+]

--- a/src/app/src/util.ts
+++ b/src/app/src/util.ts
@@ -194,11 +194,13 @@ export function getCategoryForAgencies(agencies: Agency[]): Category {
     throw new Error(`Category not found for this agency list ${agencies}`);
 }
 
-export function getAmountCategory(amount: number): AmountCategory {
+export function getAmountCategory(
+    amount: number,
+    categories: AmountCategory[] = AMOUNT_CATEGORIES
+): AmountCategory {
     const category =
-        AMOUNT_CATEGORIES.find(
-            amountCategory => amount >= amountCategory.min
-        ) ?? AMOUNT_CATEGORIES[AMOUNT_CATEGORIES.length - 1];
+        categories.find(amountCategory => amount >= amountCategory.min) ??
+        categories[categories.length - 1];
 
     if (!category) {
         throw Error(`Could not find amount category for amount: ${amount}`);


### PR DESCRIPTION
## Overview
Add a choropleth map that colorizes states according to the % of their population living in a disadvantaged census tract as determined by the [Climate and Economic Justice Screening Tool](https://screeningtool.geoplatform.gov/en/downloads#3/33.47/-97.5).

Closes #92

### Demo
<img width="1109" alt="Screenshot 2023-04-10 at 3 45 03 PM" src="https://user-images.githubusercontent.com/38668450/230984177-1427be61-b965-41ae-bc23-2fa14b439af2.png">

## Testing Instructions

- scripts/server
- click "Disadvantaged communities"

 ## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [ ] CI passes after rebase
