### PR TITLE
Place category spending percentages directly next to bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ and this project adheres to
     [#89](https://github.com/azavea/green-equity-demo/pull/89)
 -   Change animated map to use per-capita data
     [#96](https://github.com/azavea/green-equity-demo/pull/96)
+-   Place category spending percentages directly next to bars
+    [#103](https://github.com/azavea/green-equity-demo/pull/103)
 
 ### Fixed
 

--- a/src/app/src/components/PerCapitaMap/SpendingTooltip.tsx
+++ b/src/app/src/components/PerCapitaMap/SpendingTooltip.tsx
@@ -6,17 +6,19 @@ import {
     CardBody,
     CardHeader,
     Heading,
+    HStack,
     Stack,
     StackDivider,
     StyleFunctionProps,
     Text,
-    Progress,
 } from '@chakra-ui/react';
 import { createPortal } from 'react-dom';
 
 import { Category, isCategory } from '../../enums';
 import { abbreviateNumber } from '../../util';
 import { StateSpending } from '../../types/api';
+
+const FULL_BAR_WIDTH = 194;
 
 export default function SpendingTooltip({
     state,
@@ -115,11 +117,20 @@ function SpendingBars({
 }
 
 function SpendingBar({ cat, percent }: { cat: Category; percent: number }) {
+    const thisWidth = Math.round((percent / 100) * FULL_BAR_WIDTH);
+
     return (
         <>
-            <Text>{cat.toString()}:</Text>
-            <Text>{percent}%</Text>
-            <Progress mb={2} colorScheme='tooltip' size='lg' value={percent} />
+            <Text mb={1}>{cat.toString()}:</Text>
+            <HStack spacing={2} mb={2}>
+                <Box
+                    bg='#465EB5'
+                    height={4}
+                    width={`${thisWidth}px`}
+                    aria-label={`${percent}%`}
+                />
+                <Text>{percent}%</Text>
+            </HStack>
         </>
     );
 }
@@ -137,7 +148,7 @@ const variants = {
             container: {
                 ...props.theme.components.Card.variants.elevated.container,
                 overflow: 'clip', // https://github.com/twbs/bootstrap/issues/37010
-                minWidth: '194px',
+                minWidth: `${FULL_BAR_WIDTH}px`,
                 padding: '0',
                 border: '0',
             },


### PR DESCRIPTION
## Overview
Place category spending percentages directly next to bars. Just use a styled `<Box>` for the visual element instead of `<Progress>`, which comes with an inaccurate role attribute.

Closes #94

### Demo
<img width="256" alt="Screenshot 2023-04-11 at 3 49 03 PM" src="https://user-images.githubusercontent.com/38668450/231272930-77b53572-c092-4243-9be2-5e464e8434b2.png">


### Notes
The original designs for the tooltip were left-aligned. When making the site responsive, we adjusted it to be centered. I think that as of this PR we could consider moving it back to left-aligned, but wanted to ask around first.


## Testing Instructions

- scripts/server
- View tooltips

 ## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
