### PR TITLE
Recolor state borders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ and this project adheres to
     [#96](https://github.com/azavea/green-equity-demo/pull/96)
 -   Place category spending percentages directly next to bars
     [#103](https://github.com/azavea/green-equity-demo/pull/103)
+-   [#110](https://github.com/azavea/green-equity-demo/pull/110)
 
 ### Fixed
 

--- a/src/app/src/constants.ts
+++ b/src/app/src/constants.ts
@@ -18,10 +18,10 @@ export const QUARTILE_CATEGORIES: AmountCategory[] = [
 ];
 
 export const STATE_STYLE_BASE = Object.freeze({
-    color: 'black',
+    color: 'white',
     weight: 0.62,
     fill: true,
-    fillColor: 'white',
+    fillColor: 'lightgray',
     fillOpacity: 1,
 });
 


### PR DESCRIPTION
## Overview

Changes the state borders to white and the fill color of states with no funding to light gray.

Closes #73 

### Demo

![image](https://user-images.githubusercontent.com/64238570/231787689-1ec8e8b2-6a00-4509-9ec2-0b35ae10ee64.png)

## Testing Instructions

- In this branch run `./scripts/server` and navigate to `http://localhost:8765/`
- Ensure:
  - [ ] The states' border colors are white
  - [x] They are also white when hovered/mouseover'd
  - [x] In the "Civil Works" tab: NV, UT, CO, NH, RI, & DE are light gray with white borders

 ## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [ ] CI passes after rebase
