### PR TITLE
Edit money curves to appear to go 'up'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,8 @@ and this project adheres to
     [#96](https://github.com/azavea/green-equity-demo/pull/96)
 -   Place category spending percentages directly next to bars
     [#103](https://github.com/azavea/green-equity-demo/pull/103)
--   [#110](https://github.com/azavea/green-equity-demo/pull/110)
+-   Recolor state borders [#110](https://github.com/azavea/green-equity-demo/pull/110)
+-   Make money travel curves go 'up' [#112](https://github.com/azavea/green-equity-demo/pull/112)
 
 ### Fixed
 

--- a/src/app/src/components/AnimatedArcsAndMap/useCreateArcPath.tsx
+++ b/src/app/src/components/AnimatedArcsAndMap/useCreateArcPath.tsx
@@ -101,7 +101,8 @@ function getBezierOffsetLatLng(end: L.LatLngTuple): L.LatLngTuple {
     const r = Math.sqrt(Math.pow(offsetX, 2) + Math.pow(offsetY, 2));
     const theta = Math.atan2(offsetY, offsetX);
 
-    const thetaOffset = 3.14 / 10;
+    const thetaOffsetDist = Math.PI / 10;
+    const thetaOffset = offsetX < 0 ? thetaOffsetDist * -1 : thetaOffsetDist;
 
     const r2 = r / 2 / Math.cos(thetaOffset);
     const theta2 = theta + thetaOffset;


### PR DESCRIPTION
## Overview

These changes check if the `offsetX` value in the `getBezierOffsetLatLng` function in the `useCreateArcPath` hook is negative (i.e. the end of the arc is West of DC), then to set the `thetaOffset` value to be on the other side of the polar coordinate "line" between our points' offset values. Without doing this all the curves will make a hurricane-like pattern and not quite look right. 

I got to this from looking at [the blog post](https://ryancatalani.medium.com/creating-consistently-curved-lines-on-leaflet-b59bc03fa9dc) that I believe this team forked the original implementation from.

Closes #88 

### Demo

Before: 
<img width="577" alt="image" src="https://user-images.githubusercontent.com/64238570/232161076-c3b3dbff-947b-4acc-ab30-4ec63cd56269.png">

After: 
<img width="580" alt="image" src="https://user-images.githubusercontent.com/64238570/232160953-2ada044b-57f8-4622-a831-c76919cf3433.png">

## Testing Instructions

- In this branch, run `./scripts/server` and navigate to the page
- Play the animated map and ensure:
  - [ ] The arcs all curve up (both going east and west (there are only a few east-bound examples))
  - [ ] The curves are mostly distinguishable from each other (sorry Midwest)

 ## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [ ] CI passes after rebase
