### PR TITLE
Fix spending over time data for animated map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,5 +86,6 @@ and this project adheres to
 -   Reposition animated spending bucket over DC
     [#85](https://github.com/azavea/green-equity-demo/pull/85)
 -   Optimize arc animation [#97](https://github.com/azavea/green-equity-demo/pull/97)
+-   Fix spending over time data for animated map [#114](https://github.com/azavea/green-equity-demo/pull/114)
 
 ### Removed

--- a/src/app/dataScripts/fetchSpendingOverTimeData.ts
+++ b/src/app/dataScripts/fetchSpendingOverTimeData.ts
@@ -112,15 +112,17 @@ function cleanDataDump(
     const perCapitaSpendingOverMonths: MonthlySpendingOverTime = [];
     dataDump.results.reduce(
         (sum, { aggregated_amount, time_period: { fiscal_year, month } }) => {
-            const aggregatedPerCapita = sum + aggregated_amount / population;
+            const aggregatedTotal = sum + aggregated_amount;
+            const aggregatedPerCapita = aggregatedTotal / population;
             perCapitaSpendingOverMonths.push({
                 per_capita: aggregatedPerCapita,
+                total: aggregatedTotal,
                 time_period: {
                     fiscal_year: parseInt(fiscal_year),
                     month: parseInt(month),
                 },
             });
-            return aggregatedPerCapita;
+            return aggregatedTotal;
         },
         0
     );

--- a/src/app/src/components/AnimatedArcsAndMap/AnimatedTotalSpendingBucket.tsx
+++ b/src/app/src/components/AnimatedArcsAndMap/AnimatedTotalSpendingBucket.tsx
@@ -36,7 +36,7 @@ export default function AnimatedTotalSpendingBucket({
             const totalAwardsAtTime: number = Object.values(
                 spendingAtTimeByState
             ).reduce((sum, stateResults) => {
-                sum += stateResults && stateResults.per_capita;
+                sum += stateResults?.total ?? 0;
                 return sum;
             }, 0);
             totalAwardsAtTime && setTotalSpendingAtTime(totalAwardsAtTime);

--- a/src/app/src/types/api.d.ts
+++ b/src/app/src/types/api.d.ts
@@ -66,6 +66,7 @@ export type SpendingOverTimeByStateRequest = {
 
 export type MonthlySpendingOverTime = {
     per_capita: number;
+    total?: number;
     time_period: {
         fiscal_year: number;
         month: number;
@@ -92,6 +93,7 @@ export type MonthlySpendingOverTimeByState = {
 export type SpendingByGeographyAtMonth = {
     [k: string]: {
         per_capita: number;
+        total?: number;
         time_period: {
             fiscal_year: number;
             month: number;


### PR DESCRIPTION
## Overview

These changes fix how spending over months for each state is calculated and adds a total spending amount to get the AnimatedTotalSpendingBucket to "drain" correctly. Before, the aggregated spending was per capita by state and the total it was subtracting from was the raw total in the BIL, meaning it didn't go down by very much at all.

There was also a bug in the aggregation math that was adding too little each month and thus the coloring on the map's states didn't match the above-the-fold map at the end of the animation. 

Closes #104 

### Demo

![image](https://user-images.githubusercontent.com/64238570/232878354-ccd2818d-3db8-492c-b944-cf9c8e3f7029.png)

![2023-04-18 14 59 04](https://user-images.githubusercontent.com/64238570/232878388-2cc83650-9e3c-4381-8374-884c45c06c02.gif)

### Notes

Not sure if it's because of the particular start time we are using but the bucket starts at 418B instead of 550B

![image](https://user-images.githubusercontent.com/64238570/232878720-e6450928-cf3d-4d0e-9aac-e730324b5125.png)


## Testing Instructions

- In this branch delete `src/app/sr/data/monthly.spending.json` (This may be unnecessary but the fetch data script would skip if the file existed, unless there is a flag I didn't find, which, if so, do that instead)
- run `./scripts/fetch-data` (I sometimes had to do this twice because of an exit with code 1, but no output?)
- run `./scripts/server` and navigate to the homepage
- Scroll down and hit the play button on the map and ensure:
  - [x] The app plays as it normally does
  - [x] The bucket drains and matches the expected remaining amount at the end (268B)
  - [x] At the end of the animation, the animated map has the same coloring as the top map

 ## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [ ] CI passes after rebase
